### PR TITLE
Disable send button during report submission

### DIFF
--- a/AppliverySDK/Modules/ScreenshotReport/Screens/ScreenshootPreviewScreen.swift
+++ b/AppliverySDK/Modules/ScreenshotReport/Screens/ScreenshootPreviewScreen.swift
@@ -63,21 +63,18 @@ struct ScreenshootPreviewScreen: View {
                 trailing:
                     Button(action: {
                         guard let screenshot = screenshot else { return }
-                        let newScreenShot = viewModel.exportDrawing(
+                        guard let newScreenShot = viewModel.exportDrawing(
                             image: screenshot,
                             lines: imageLines
-                        )
-                        
-                        if let newScreenShot = newScreenShot {
-                            viewModel.sendScreenshootFeedback(
-                                feedback: .init(
-                                    feedbackType: reportType,
-                                    message: description,
-                                    screenshot: imageIsSelected ? .init(image: newScreenShot) : nil,
-                                    videoURL: nil
-                                )
+                        ) else { return }
+                        viewModel.sendScreenshootFeedback(
+                            feedback: .init(
+                                feedbackType: reportType,
+                                message: description,
+                                screenshot: imageIsSelected ? .init(image: newScreenShot) : nil,
+                                videoURL: nil
                             )
-                        }
+                        )
                     }, label: {
                         Image(systemName: "location.fill")
                             .foregroundColor(.blue)
@@ -85,6 +82,7 @@ struct ScreenshootPreviewScreen: View {
                     })
                     .opacity(description.isEmpty ? 0.4 : 1)
                     .disabled(description.isEmpty)
+                    .disabled(viewModel.isReportSended == .loading)
             )
             .onAppear {
                 user = viewModel.loadUserName()

--- a/AppliverySDK/Modules/VideoReport/VideoPreviewScreen.swift
+++ b/AppliverySDK/Modules/VideoReport/VideoPreviewScreen.swift
@@ -68,6 +68,7 @@ struct VideoPreviewScreen: View {
                             .foregroundColor(.blue)
                             .rotationEffect(.degrees(10))
                     })
+                    .disabled(viewModel.isReportSended == .loading)
             )
             .onAppear {
                 user = viewModel.loadUserName()


### PR DESCRIPTION
This pull request makes improvements to the feedback submission process for both screenshot and video reporting screens. The main focus is on preventing users from submitting multiple reports while a previous submission is still in progress.