### PR TITLE
Feature/apple 51 improve error feedback when app install fails due to

### DIFF
--- a/AppliveryBehaviorTests/MockData/ConfigMockData.swift
+++ b/AppliveryBehaviorTests/MockData/ConfigMockData.swift
@@ -9,7 +9,6 @@ import Foundation
 @testable import Applivery
 
 struct ConfigMockData {
-    
     static let config = Config(
         status: true,
         data: ConfigData(
@@ -32,5 +31,19 @@ struct ConfigMockData {
             name: "TestConfig",
             description: "This is a test config"
         )
+    )
+}
+
+extension SDKData {
+    static let mock = Self.init(
+        minVersion: "1.0.0",
+        forceUpdate: true,
+        lastBuildId: "some-build-id",
+        mustUpdateMsg: nil,
+        ota: false,
+        lastBuildVersion: nil,
+        updateMsg: nil,
+        forceAuth: false,
+        lastBuildSize: 5000000000
     )
 }

--- a/AppliveryBehaviorTests/MockData/ConfigMockData.swift
+++ b/AppliveryBehaviorTests/MockData/ConfigMockData.swift
@@ -22,7 +22,8 @@ struct ConfigMockData {
                     ota: true,
                     lastBuildVersion: "1.0.1",
                     updateMsg: "Update available",
-                    forceAuth: false
+                    forceAuth: false,
+                    lastBuildSize: 300000000
                 )
             ),
             id: "configId",

--- a/AppliveryBehaviorTests/Mocks/AppMock.swift
+++ b/AppliveryBehaviorTests/Mocks/AppMock.swift
@@ -18,6 +18,7 @@ class AppMock: AppProtocol {
     var stubVersionName: String = "NO VERSION SET"
     var stubLanguage: String = "NO LANGUAGE SET"
     var stubOpenUrlResult = false
+    var stubDeviceAvailableSpace: Int64 = 100_000_000_000 // default 100GB
 
     // Outputs
     var spyOpenUrl = (called: false, url: "")
@@ -121,5 +122,9 @@ class AppMock: AppProtocol {
         if let firstOption = options.first {
             selectionHandler(firstOption)
         }
+    }
+
+    func deviceAvailableSpace() throws -> Int64 {
+        return stubDeviceAvailableSpace
     }
 }

--- a/AppliveryBehaviorTests/Mocks/ConfigServiceMock.swift
+++ b/AppliveryBehaviorTests/Mocks/ConfigServiceMock.swift
@@ -38,7 +38,8 @@ final class ConfigServiceMock: ConfigServiceProtocol {
                 ota: false,
                 lastBuildVersion: nil,
                 updateMsg: nil,
-                forceAuth: false
+                forceAuth: false,
+                lastBuildSize: nil
             )
             let sdk = SDK(ios: sdkData)
             let configData = ConfigData(

--- a/AppliveryBehaviorTests/Mocks/DownloadServiceMock.swift
+++ b/AppliveryBehaviorTests/Mocks/DownloadServiceMock.swift
@@ -1,0 +1,26 @@
+//
+//  DownloadServiceMock.swift
+//  AppliverySDK
+//
+//  Created by Abigail Dominguez Morlans on 30/9/25.
+//  Copyright © 2025 Applivery S.L. All rights reserved.
+//
+
+@testable import Applivery
+
+class DownloadServiceMock: DownloadServiceProtocol {
+    var stubbedToken: DownloadToken?
+    var stubbedURL: String?
+    var fetchDownloadTokenCalled = false
+    var downloadURLCalled = false
+
+    func fetchDownloadToken(with buildId: String) async -> DownloadToken? {
+        fetchDownloadTokenCalled = true
+        return stubbedToken
+    }
+
+    func downloadURL(_ lastBuildId: String) async -> String? {
+        downloadURLCalled = true
+        return stubbedURL
+    }
+}

--- a/AppliveryBehaviorTests/Mocks/LoginRepositoryMock.swift
+++ b/AppliveryBehaviorTests/Mocks/LoginRepositoryMock.swift
@@ -1,0 +1,23 @@
+//
+//  LoginRepositoryMock.swift
+//  AppliverySDK
+//
+//  Created by Abigail Dominguez Morlans on 30/9/25.
+//  Copyright © 2025 Applivery S.L. All rights reserved.
+//
+
+import Foundation
+@testable import Applivery
+
+class LoginRepositoryMock: LoginRepositoryProtocol {
+    var shouldSucceed = false
+    var shouldReturn401 = false
+    func login(loginData: LoginData) async throws -> AccessToken {
+        if shouldReturn401 { throw APIError.statusCode(401) }
+        if shouldSucceed { return AccessToken(token: "token") }
+        throw APIError.statusCode(500)
+    }
+    func bind(user: User) async throws -> CustomLogin { fatalError() }
+    func getRedirctURL() async throws -> URL? { return URL(string: "https://applivery.com") }
+    func unbindUser() {}
+}

--- a/AppliveryBehaviorTests/Mocks/MockSessionPersister.swift
+++ b/AppliveryBehaviorTests/Mocks/MockSessionPersister.swift
@@ -1,0 +1,34 @@
+//
+//  MockSessionPersister.swift
+//  AppliverySDK
+//
+//  Created by Abigail Dominguez Morlans on 30/9/25.
+//  Copyright © 2025 Applivery S.L. All rights reserved.
+//
+
+@testable import Applivery
+
+class MockSessionPersister: SessionPersisterProtocol {
+    var savedUserName: String?
+    var didSaveUserName = false
+    var userNameToLoad: String = ""
+    var accessTokenToLoad: AccessToken? = nil
+
+    func loadAccessToken() -> AccessToken? {
+        return accessTokenToLoad
+    }
+
+    func saveUserName(userName: String) {
+        didSaveUserName = true
+        savedUserName = userName
+    }
+
+    func loadUserName() -> String {
+        return userNameToLoad
+    }
+
+    func removeUser() {
+        userNameToLoad = ""
+        savedUserName = nil
+    }
+}

--- a/AppliveryBehaviorTests/ServicesTests/LoginServiceTests.swift
+++ b/AppliveryBehaviorTests/ServicesTests/LoginServiceTests.swift
@@ -1,0 +1,262 @@
+//
+//  LoginServiceTests.swift
+//  AppliverySDK
+//
+//  Created by Abigail Dominguez Morlans on 30/9/25.
+//  Copyright © 2025 Applivery S.L. All rights reserved.
+//
+
+import Testing
+@testable import Applivery
+
+struct LoginServiceTests {
+    @Test
+    func testLoginSuccess() async throws {
+        let loginRepository = LoginRepositoryMock()
+        let configService = ConfigServiceMock()
+        let downloadService = DownloadServiceMock()
+        let globalConfig = GlobalConfig.shared
+        let sessionPersister = MockSessionPersister()
+        let app = AppMock()
+        let keychain = MockKeychainManager()
+        let forceUpdateConfig = UpdateConfigResponse(
+            config: SDKData(
+                minVersion: "1.0.0",
+                forceUpdate: true,
+                lastBuildId: "some-build-id",
+                mustUpdateMsg: nil,
+                ota: false,
+                lastBuildVersion: nil,
+                updateMsg: nil,
+                forceAuth: false,
+                lastBuildSize: 5000000000
+            ),
+            version: "0.9.0",
+            buildNumber: "100"
+        )
+        configService.currentConfigResponse = forceUpdateConfig
+        let loginService = LoginService(
+            loginRepository: loginRepository,
+            configService: configService,
+            downloadService: downloadService,
+            globalConfig: globalConfig,
+            sessionPersister: sessionPersister,
+            app: app,
+            keychain: keychain
+        )
+        loginRepository.shouldSucceed = true
+        let loginData = LoginData(provider: "provider", payload: .init(user: "test@applivery.com", password: "pass"))
+        await loginService.login(loginData: loginData)
+        #expect(sessionPersister.didSaveUserName)
+    }
+
+    @Test
+    func testLoginFailure401() async {
+        let loginRepository = LoginRepositoryMock()
+        let configService = ConfigServiceMock()
+        let downloadService = DownloadServiceMock()
+        let globalConfig = GlobalConfig.shared
+        let sessionPersister = MockSessionPersister()
+        let app = AppMock()
+        let keychain = MockKeychainManager()
+        let forceUpdateConfig = UpdateConfigResponse(
+            config: SDKData(
+                minVersion: "1.0.0",
+                forceUpdate: true,
+                lastBuildId: "some-build-id",
+                mustUpdateMsg: nil,
+                ota: false,
+                lastBuildVersion: nil,
+                updateMsg: nil,
+                forceAuth: false,
+                lastBuildSize: 5000000000
+            ),
+            version: "0.9.0",
+            buildNumber: "100"
+        )
+        configService.currentConfigResponse = forceUpdateConfig
+        let loginService = LoginService(
+            loginRepository: loginRepository,
+            configService: configService,
+            downloadService: downloadService,
+            globalConfig: globalConfig,
+            sessionPersister: sessionPersister,
+            app: app,
+            keychain: keychain
+        )
+        loginRepository.shouldReturn401 = true
+        let loginData = LoginData(provider: "provider", payload: .init(user: "test@applivery.com", password: "pass"))
+        await loginService.login(loginData: loginData)
+        // No assertion for SafariManager side effect since it is now a noop
+    }
+
+    @Test
+    func testRequestAuthorizationWithToken() async {
+        let loginRepository = LoginRepositoryMock()
+        let configService = ConfigServiceMock()
+        let downloadService = DownloadServiceMock()
+        let globalConfig = GlobalConfig.shared
+        let sessionPersister = MockSessionPersister()
+        let app = AppMock()
+        let keychain = MockKeychainManager()
+        let forceUpdateConfig = UpdateConfigResponse(
+            config: SDKData(
+                minVersion: "1.0.0",
+                forceUpdate: true,
+                lastBuildId: "some-build-id",
+                mustUpdateMsg: nil,
+                ota: false,
+                lastBuildVersion: nil,
+                updateMsg: nil,
+                forceAuth: false,
+                lastBuildSize: 5000000000
+            ),
+            version: "0.9.0",
+            buildNumber: "100"
+        )
+        configService.currentConfigResponse = forceUpdateConfig
+        let loginService = LoginService(
+            loginRepository: loginRepository,
+            configService: configService,
+            downloadService: downloadService,
+            globalConfig: globalConfig,
+            sessionPersister: sessionPersister,
+            app: app,
+            keychain: keychain
+        )
+        // Ensure bundle ID is set before storing the token
+        app.stubBundleID = "com.applivery.test"
+        try? keychain.store("token", for: app.stubBundleID)
+        downloadService.stubbedURL = "https://applivery.com/app.ipa"
+        var downloadCalled = false
+        loginService.requestAuthorization(onResult: { _ in downloadCalled = true })
+        waitUntil { downloadService.downloadURLCalled && downloadCalled }
+        #expect(downloadService.downloadURLCalled)
+        #expect(downloadCalled)
+    }
+
+    @Test
+    func testRequestAuthorizationWithoutToken() async {
+        let loginRepository = LoginRepositoryMock()
+        let configService = ConfigServiceMock()
+        let downloadService = DownloadServiceMock()
+        let globalConfig = GlobalConfig.shared
+        let sessionPersister = MockSessionPersister()
+        let app = AppMock()
+        let keychain = MockKeychainManager()
+        let forceUpdateConfig = UpdateConfigResponse(
+            config: SDKData(
+                minVersion: "1.0.0",
+                forceUpdate: true,
+                lastBuildId: "some-build-id",
+                mustUpdateMsg: nil,
+                ota: false,
+                lastBuildVersion: nil,
+                updateMsg: nil,
+                forceAuth: false,
+                lastBuildSize: 5000000000
+            ),
+            version: "0.9.0",
+            buildNumber: "100"
+        )
+        configService.currentConfigResponse = forceUpdateConfig
+        let loginService = LoginService(
+            loginRepository: loginRepository,
+            configService: configService,
+            downloadService: downloadService,
+            globalConfig: globalConfig,
+            sessionPersister: sessionPersister,
+            app: app,
+            keychain: keychain
+        )
+        try? keychain.remove(for: "com.applivery.test")
+        var result: UpdateResult?
+        loginService.requestAuthorization { r in result = r }
+        waitUntil { result != nil }
+        #expect(result == .failure(error: .authRequired))
+    }
+
+    @Test
+    func testDownloadInsufficientDiskSpace() async {
+        let loginRepository = LoginRepositoryMock()
+        let configService = ConfigServiceMock()
+        let downloadService = DownloadServiceMock()
+        let globalConfig = GlobalConfig.shared
+        let sessionPersister = MockSessionPersister()
+        let app = AppMock()
+        let keychain = MockKeychainManager()
+        let forceUpdateConfig = UpdateConfigResponse(
+            config: SDKData(
+                minVersion: "1.0.0",
+                forceUpdate: true,
+                lastBuildId: "some-build-id",
+                mustUpdateMsg: nil,
+                ota: false,
+                lastBuildVersion: nil,
+                updateMsg: nil,
+                forceAuth: false,
+                lastBuildSize: 5000000000
+            ),
+            version: "0.9.0",
+            buildNumber: "100"
+        )
+        configService.currentConfigResponse = forceUpdateConfig
+        let loginService = LoginService(
+            loginRepository: loginRepository,
+            configService: configService,
+            downloadService: downloadService,
+            globalConfig: globalConfig,
+            sessionPersister: sessionPersister,
+            app: app,
+            keychain: keychain
+        )
+        downloadService.stubbedURL = nil
+        var result: UpdateResult?
+        loginService.download { r in result = r }
+        waitUntil { result != nil }
+        #expect(result == .failure(error: .noDiskSpaceAvailable))
+    }
+
+    @Test
+    func testDownloadSufficientDiskSpace() async {
+        let loginRepository = LoginRepositoryMock()
+        let configService = ConfigServiceMock()
+        let downloadService = DownloadServiceMock()
+        let globalConfig = GlobalConfig.shared
+        let sessionPersister = MockSessionPersister()
+        let app = AppMock()
+        let keychain = MockKeychainManager()
+        let forceUpdateConfig = UpdateConfigResponse(
+            config: SDKData(
+                minVersion: "1.0.0",
+                forceUpdate: true,
+                lastBuildId: "some-build-id",
+                mustUpdateMsg: nil,
+                ota: false,
+                lastBuildVersion: nil,
+                updateMsg: nil,
+                forceAuth: false,
+                lastBuildSize: 5000000000
+            ),
+            version: "0.9.0",
+            buildNumber: "100"
+        )
+        configService.currentConfigResponse = forceUpdateConfig
+        let loginService = LoginService(
+            loginRepository: loginRepository,
+            configService: configService,
+            downloadService: downloadService,
+            globalConfig: globalConfig,
+            sessionPersister: sessionPersister,
+            app: app,
+            keychain: keychain
+        )
+        downloadService.stubbedURL = "https://applivery.com/app.ipa"
+        var result: UpdateResult?
+        loginService.download { r in result = r }
+        waitUntil { result != nil && downloadService.downloadURLCalled }
+
+        #expect(result?.type == .success)
+        #expect(downloadService.downloadURLCalled)
+    }
+}

--- a/AppliveryBehaviorTests/ServicesTests/LoginServiceTests.swift
+++ b/AppliveryBehaviorTests/ServicesTests/LoginServiceTests.swift
@@ -173,7 +173,8 @@ struct LoginServiceTests {
         var result: UpdateResult?
         loginService.requestAuthorization { r in result = r }
         waitUntil { result != nil }
-        #expect(result == .failure(error: .authRequired))
+        #expect(result?.type == .error)
+        #expect(result?.error == .authRequired)
     }
 
     @Test
@@ -210,11 +211,12 @@ struct LoginServiceTests {
             app: app,
             keychain: keychain
         )
-        downloadService.stubbedURL = nil
+        app.stubDeviceAvailableSpace = 1000
         var result: UpdateResult?
         loginService.download { r in result = r }
         waitUntil { result != nil }
-        #expect(result == .failure(error: .noDiskSpaceAvailable))
+        #expect(result?.type == .error)
+        #expect(result?.error == .noDiskSpaceAvailable)
     }
 
     @Test
@@ -241,6 +243,8 @@ struct LoginServiceTests {
             version: "0.9.0",
             buildNumber: "100"
         )
+        app.stubDeviceAvailableSpace = 6000000000
+        app.stubOpenUrlResult = true
         configService.currentConfigResponse = forceUpdateConfig
         let loginService = LoginService(
             loginRepository: loginRepository,
@@ -251,11 +255,11 @@ struct LoginServiceTests {
             app: app,
             keychain: keychain
         )
+
         downloadService.stubbedURL = "https://applivery.com/app.ipa"
         var result: UpdateResult?
         loginService.download { r in result = r }
         waitUntil { result != nil && downloadService.downloadURLCalled }
-
         #expect(result?.type == .success)
         #expect(downloadService.downloadURLCalled)
     }

--- a/AppliveryBehaviorTests/ServicesTests/LoginServiceTests.swift
+++ b/AppliveryBehaviorTests/ServicesTests/LoginServiceTests.swift
@@ -20,17 +20,7 @@ struct LoginServiceTests {
         let app = AppMock()
         let keychain = MockKeychainManager()
         let forceUpdateConfig = UpdateConfigResponse(
-            config: SDKData(
-                minVersion: "1.0.0",
-                forceUpdate: true,
-                lastBuildId: "some-build-id",
-                mustUpdateMsg: nil,
-                ota: false,
-                lastBuildVersion: nil,
-                updateMsg: nil,
-                forceAuth: false,
-                lastBuildSize: 5000000000
-            ),
+            config: SDKData.mock,
             version: "0.9.0",
             buildNumber: "100"
         )
@@ -60,17 +50,7 @@ struct LoginServiceTests {
         let app = AppMock()
         let keychain = MockKeychainManager()
         let forceUpdateConfig = UpdateConfigResponse(
-            config: SDKData(
-                minVersion: "1.0.0",
-                forceUpdate: true,
-                lastBuildId: "some-build-id",
-                mustUpdateMsg: nil,
-                ota: false,
-                lastBuildVersion: nil,
-                updateMsg: nil,
-                forceAuth: false,
-                lastBuildSize: 5000000000
-            ),
+            config: SDKData.mock,
             version: "0.9.0",
             buildNumber: "100"
         )
@@ -100,17 +80,7 @@ struct LoginServiceTests {
         let app = AppMock()
         let keychain = MockKeychainManager()
         let forceUpdateConfig = UpdateConfigResponse(
-            config: SDKData(
-                minVersion: "1.0.0",
-                forceUpdate: true,
-                lastBuildId: "some-build-id",
-                mustUpdateMsg: nil,
-                ota: false,
-                lastBuildVersion: nil,
-                updateMsg: nil,
-                forceAuth: false,
-                lastBuildSize: 5000000000
-            ),
+            config: SDKData.mock,
             version: "0.9.0",
             buildNumber: "100"
         )
@@ -145,17 +115,7 @@ struct LoginServiceTests {
         let app = AppMock()
         let keychain = MockKeychainManager()
         let forceUpdateConfig = UpdateConfigResponse(
-            config: SDKData(
-                minVersion: "1.0.0",
-                forceUpdate: true,
-                lastBuildId: "some-build-id",
-                mustUpdateMsg: nil,
-                ota: false,
-                lastBuildVersion: nil,
-                updateMsg: nil,
-                forceAuth: false,
-                lastBuildSize: 5000000000
-            ),
+            config: SDKData.mock,
             version: "0.9.0",
             buildNumber: "100"
         )
@@ -187,17 +147,7 @@ struct LoginServiceTests {
         let app = AppMock()
         let keychain = MockKeychainManager()
         let forceUpdateConfig = UpdateConfigResponse(
-            config: SDKData(
-                minVersion: "1.0.0",
-                forceUpdate: true,
-                lastBuildId: "some-build-id",
-                mustUpdateMsg: nil,
-                ota: false,
-                lastBuildVersion: nil,
-                updateMsg: nil,
-                forceAuth: false,
-                lastBuildSize: 5000000000
-            ),
+            config: SDKData.mock,
             version: "0.9.0",
             buildNumber: "100"
         )
@@ -229,17 +179,7 @@ struct LoginServiceTests {
         let app = AppMock()
         let keychain = MockKeychainManager()
         let forceUpdateConfig = UpdateConfigResponse(
-            config: SDKData(
-                minVersion: "1.0.0",
-                forceUpdate: true,
-                lastBuildId: "some-build-id",
-                mustUpdateMsg: nil,
-                ota: false,
-                lastBuildVersion: nil,
-                updateMsg: nil,
-                forceAuth: false,
-                lastBuildSize: 5000000000
-            ),
+            config: SDKData.mock,
             version: "0.9.0",
             buildNumber: "100"
         )

--- a/AppliveryBehaviorTests/ServicesTests/UpdateServiceTests.swift
+++ b/AppliveryBehaviorTests/ServicesTests/UpdateServiceTests.swift
@@ -128,7 +128,8 @@ struct UpdateServiceTests {
                 ota: false,
                 lastBuildVersion: nil,
                 updateMsg: nil,
-                forceAuth: false
+                forceAuth: false,
+                lastBuildSize: nil
             ),
             version: "0.9.0",
             buildNumber: "100"
@@ -152,7 +153,8 @@ struct UpdateServiceTests {
                 ota: true,
                 lastBuildVersion: "2.0.0",
                 updateMsg: nil,
-                forceAuth: false
+                forceAuth: false,
+                lastBuildSize: nil
             ),
             version: "1.0.0",
             buildNumber: "100"

--- a/AppliverySDK/Applivery/AppliverySDK.swift
+++ b/AppliverySDK/Applivery/AppliverySDK.swift
@@ -41,7 +41,7 @@ import UIKit
 ///
 /// This enumeration is compatible with Objective-C and provides a list of detailed errors that
 /// describe potential failures during the update process.
-@objc public enum UpdateError: Int {
+@objc public enum UpdateError: Int, Error {
 
     /// No error; used to represent a state without errors.
     case noError = 0
@@ -60,6 +60,12 @@ import UIKit
 
     /// Indicates that the app is up to date.
     case isUpToDate = 1005
+
+    /// Indicates there was an error retrieving free space in the device
+    case unableToDetermineFreeSpace = 1006
+
+    /// Indicates there is not enough free space in the device
+    case noDiskSpaceAvailable = 1007
 
 }
 

--- a/AppliverySDK/Data/Persisters/ConfigPersister.swift
+++ b/AppliverySDK/Data/Persisters/ConfigPersister.swift
@@ -16,6 +16,7 @@ let kOtaUpdateKey			= "APPLIVERY_OTA_UPDATE_KEY"
 let kLastBuildVersion		= "APPLIVERY_LAST_BUILD_VERSION"
 let kOtaUpdateMessageKey	= "APPLIVERY_OTA_UPDATE_MESSAGE"
 let kForceAuth				= "APPLIVERY_FORCE_AUTH"
+let kLastBuildSize          = "APPLIVERY_LASTBUILDSIZE"
 
 protocol UserDefaultsProtocol {
 	func value(forKey key: String) -> Any?
@@ -43,14 +44,12 @@ class ConfigPersister: NSObject {
 	///  Get the current config stored on disk
 	///  - returns: config object with the data stored. Could be nil if no previus data was saved
     func getConfig() -> SDKData? {
-        
 		guard
 			let forceUpdate			= self.userDefaults.value(forKey: kForceUpdateKey)		as? Bool,
 			let lastBuildId			= self.userDefaults.value(forKey: kLastBuildId)			as? String,
 			let otaUpdate			= self.userDefaults.value(forKey: kOtaUpdateKey)		as? Bool,
 			let lastBuildVersion	= self.userDefaults.value(forKey: kLastBuildVersion)	as? String
 			else { return nil }
-
         let sdkData = SDKData(
             minVersion: self.userDefaults.value(forKey: kMinVersionKey) as? String ?? "",
             forceUpdate: forceUpdate,
@@ -59,7 +58,8 @@ class ConfigPersister: NSObject {
             ota: otaUpdate,
             lastBuildVersion: lastBuildVersion,
             updateMsg: self.userDefaults.value(forKey: kForceUpdateMessageKey) as? String ?? "",
-            forceAuth: self.userDefaults.value(forKey: kForceAuth) as? Bool ?? false
+            forceAuth: self.userDefaults.value(forKey: kForceAuth) as? Bool ?? false,
+            lastBuildSize: self.userDefaults.value(forKey: kLastBuildSize) as? Int
         )
 
 		return sdkData
@@ -74,6 +74,7 @@ class ConfigPersister: NSObject {
         self.userDefaults.setValue(config.lastBuildVersion as AnyObject?, forKey: kLastBuildVersion)
         self.userDefaults.setValue(config.updateMsg as AnyObject?, forKey: kOtaUpdateMessageKey)
 		self.userDefaults.set(config.forceAuth, forKey: kForceAuth)
+        self.userDefaults.setValue(config.lastBuildSize, forKey: kLastBuildSize)
 
 		if self.userDefaults.synchronize() {
 			logInfo("Applivery configuration was updated")

--- a/AppliverySDK/Data/Persisters/SessionPersister.swift
+++ b/AppliverySDK/Data/Persisters/SessionPersister.swift
@@ -27,12 +27,7 @@ protocol SessionPersisterProtocol {
 
 struct SessionPersister: SessionPersisterProtocol {
 	let userDefaults: UserDefaultsProtocol
-	
-//	func save(accessToken: AccessToken?) {
-//		self.userDefaults.set(accessToken, forKey: kAccessTokenKey)
-//		_ = self.userDefaults.synchronize()
-//	}
-	
+
 	func loadAccessToken() -> AccessToken? {
 		let accessToken: AccessToken? = self.userDefaults.token(forKey: kAccessTokenKey)
 		return accessToken

--- a/AppliverySDK/Data/Persisters/SessionPersister.swift
+++ b/AppliverySDK/Data/Persisters/SessionPersister.swift
@@ -18,8 +18,14 @@ enum KeychainError: Error {
     case itemNotFound
 }
 
+protocol SessionPersisterProtocol {
+    func loadAccessToken() -> AccessToken?
+    func saveUserName(userName: String)
+    func loadUserName() -> String
+    func removeUser()
+}
 
-struct SessionPersister {
+struct SessionPersister: SessionPersisterProtocol {
 	let userDefaults: UserDefaultsProtocol
 	
 //	func save(accessToken: AccessToken?) {

--- a/AppliverySDK/Model/Config.swift
+++ b/AppliverySDK/Model/Config.swift
@@ -35,4 +35,5 @@ struct SDKData: Codable {
     let lastBuildVersion: String?
     let updateMsg: String?
     let forceAuth: Bool
+    let lastBuildSize: Int? // Size in bytes
 }

--- a/AppliverySDK/Services/LoginService.swift
+++ b/AppliverySDK/Services/LoginService.swift
@@ -127,12 +127,16 @@ final class LoginService: LoginServiceProtocol {
             let freeSpace = try app.deviceAvailableSpace()
             if freeSpace < (lastConfig.config?.lastBuildSize ?? 0) {
                 onResult?(.failure(error: .noDiskSpaceAvailable))
-                app.showErrorAlert("Insufficient storage")
+                DispatchQueue.main.async {
+                    self.app.showErrorAlert("Insufficient storage")
+                }
                 return
             }
         } catch {
             onResult?(.failure(error: .unableToDetermineFreeSpace))
-            app.showErrorAlert("Could not read if there is enough storage in the device")
+            DispatchQueue.main.async {
+                self.app.showErrorAlert("Could not read if there is enough storage in the device")
+            }
             return
         }
         Task {

--- a/AppliverySDK/Services/LoginService.swift
+++ b/AppliverySDK/Services/LoginService.swift
@@ -25,7 +25,7 @@ final class LoginService: LoginServiceProtocol {
     let configService: ConfigServiceProtocol
     let downloadService: DownloadServiceProtocol
     let globalConfig: GlobalConfig
-    let sessionPersister: SessionPersister
+    let sessionPersister: SessionPersisterProtocol
     let safariManager: AppliverySafariManagerProtocol
     let app: AppProtocol
     let keychain: KeychainAccessible
@@ -40,7 +40,7 @@ final class LoginService: LoginServiceProtocol {
         configService: ConfigServiceProtocol = ConfigService(),
         downloadService: DownloadServiceProtocol = DownloadService(),
         globalConfig: GlobalConfig = GlobalConfig.shared,
-        sessionPersister: SessionPersister = SessionPersister(userDefaults: UserDefaults.standard),
+        sessionPersister: SessionPersisterProtocol = SessionPersister(userDefaults: UserDefaults.standard),
         webViewManager: AppliverySafariManagerProtocol = AppliverySafariManager.shared,
         app: AppProtocol = App(),
         keychain: KeychainAccessible = Keychain()
@@ -123,7 +123,18 @@ final class LoginService: LoginServiceProtocol {
             onResult?(.failure(error: .noConfigFound))
             return
         }
-
+        do {
+            let freeSpace = try deviceAvailableSpace()
+            if freeSpace < (lastConfig.config?.lastBuildSize ?? 0) {
+                onResult?(.failure(error: .noDiskSpaceAvailable))
+                app.showErrorAlert("Insufficient storage")
+                return
+            }
+        } catch {
+            onResult?(.failure(error: .unableToDetermineFreeSpace))
+            app.showErrorAlert("Could not read if there is enough storage in the device")
+            return
+        }
         Task {
             if let url = await downloadService.downloadURL(lastBuildId) {
                 await MainActor.run {
@@ -146,7 +157,6 @@ final class LoginService: LoginServiceProtocol {
 }
 
 private extension LoginService {
-
     @MainActor
     func store(accessToken: AccessToken, userName: String) {
         logInfo("Fetched new access token: \(accessToken.token ?? "NO TOKEN")")
@@ -159,6 +169,17 @@ private extension LoginService {
                 logError(error as NSError)
                 app.showErrorAlert("Error storing token")
             }
+        }
+    }
+
+    func deviceAvailableSpace() throws -> Int64 {
+        let homeURL = URL(fileURLWithPath: NSHomeDirectory())
+        let resourceKeys: Set<URLResourceKey> = [.volumeAvailableCapacityForImportantUsageKey]
+        let resourceValues = try homeURL.resourceValues(forKeys: resourceKeys)
+        if let availableCapacity = resourceValues.volumeAvailableCapacityForImportantUsage {
+            return availableCapacity
+        } else {
+            throw UpdateError.unableToDetermineFreeSpace
         }
     }
 }

--- a/AppliverySDK/Services/LoginService.swift
+++ b/AppliverySDK/Services/LoginService.swift
@@ -124,7 +124,7 @@ final class LoginService: LoginServiceProtocol {
             return
         }
         do {
-            let freeSpace = try deviceAvailableSpace()
+            let freeSpace = try app.deviceAvailableSpace()
             if freeSpace < (lastConfig.config?.lastBuildSize ?? 0) {
                 onResult?(.failure(error: .noDiskSpaceAvailable))
                 app.showErrorAlert("Insufficient storage")
@@ -169,17 +169,6 @@ private extension LoginService {
                 logError(error as NSError)
                 app.showErrorAlert("Error storing token")
             }
-        }
-    }
-
-    func deviceAvailableSpace() throws -> Int64 {
-        let homeURL = URL(fileURLWithPath: NSHomeDirectory())
-        let resourceKeys: Set<URLResourceKey> = [.volumeAvailableCapacityForImportantUsageKey]
-        let resourceValues = try homeURL.resourceValues(forKeys: resourceKeys)
-        if let availableCapacity = resourceValues.volumeAvailableCapacityForImportantUsage {
-            return availableCapacity
-        } else {
-            throw UpdateError.unableToDetermineFreeSpace
         }
     }
 }

--- a/AppliverySDK/Services/UpdateService.swift
+++ b/AppliverySDK/Services/UpdateService.swift
@@ -110,7 +110,6 @@ final class UpdateService: UpdateServiceProtocol {
             logInfo("Force authorization is disabled - downloading last build")
             loginService.download(onResult: onResult)
         }
-
     }
 
     func isUpToDate() async -> Bool {

--- a/AppliverySDK/Wrappers/App.swift
+++ b/AppliverySDK/Wrappers/App.swift
@@ -37,13 +37,11 @@ extension AppProtocol {
 	}
 }
 
-
 class App: AppProtocol {
     private lazy var alertOta: UIAlertController = UIAlertController()
     private lazy var alertPostpone: UIAlertController = UIAlertController()
     private lazy var alertError: UIAlertController = UIAlertController()
     private lazy var alertLogin: UIAlertController = UIAlertController()
-
 
     // MARK: - Public Methods
     func deviceAvailableSpace() throws -> Int64 {
@@ -99,8 +97,6 @@ class App: AppProtocol {
 
         return true
     }
-
-
 
     func showAlert(_ message: String) {
         let alert = UIAlertController(title: literal(.appName), message: message, preferredStyle: .alert)


### PR DESCRIPTION
This pull request adds comprehensive mocking and testing support for login and update flows, introduces disk space checks before downloads, and enhances configuration handling with a new build size property. The main changes include new mock classes, expanded test coverage for login scenarios, and updates to the SDK to track and persist the last build size and disk space errors.

**Testing and Mocking Enhancements:**
* Added new mock classes for `LoginRepository`, `DownloadService`, and `SessionPersister` to facilitate isolated and robust unit testing of login and update flows. (`AppliveryBehaviorTests/Mocks/LoginRepositoryMock.swift` [[1]](diffhunk://#diff-4ace2fd7eb60d8e0a6fcd2820a7e9c6d7fdc9a5db02d4b9d735119a65d032be5R1-R23) `AppliveryBehaviorTests/Mocks/DownloadServiceMock.swift` [[2]](diffhunk://#diff-4e84350a36be7a6a57ea70a255541d654a3439093a14e0f84d58351a582f61c5R1-R26) `AppliveryBehaviorTests/Mocks/MockSessionPersister.swift` [[3]](diffhunk://#diff-565dded0812fe9e02ab214bd46ac3d99852bf48d8227581920be4d4e633706daR1-R34)
* Extended `AppMock` to allow stubbing available device space and implemented the `deviceAvailableSpace` method, enabling disk space checks in tests. (`AppliveryBehaviorTests/Mocks/AppMock.swift` [[1]](diffhunk://#diff-7b3454026ac61d3e1cfa74ec923fc47ab0a58fbd0c53e671688c6b039bcff0bcR21) [[2]](diffhunk://#diff-7b3454026ac61d3e1cfa74ec923fc47ab0a58fbd0c53e671688c6b039bcff0bcR126-R129)

**Test Coverage Improvements:**
* Added a comprehensive suite of tests for the login service, covering successful login, 401 failures, authorization requests with/without tokens, and download scenarios with sufficient and insufficient disk space. (`AppliveryBehaviorTests/ServicesTests/LoginServiceTests.swift` [AppliveryBehaviorTests/ServicesTests/LoginServiceTests.swiftR1-R266](diffhunk://#diff-a2ca7346cd3c66b4400660e2c60d9cac1c22326eef4de0050c4fcbc594e28b5cR1-R266))

**Configuration and Persistence Updates:**
* Introduced the `lastBuildSize` property to `SDKData` and ensured it is correctly persisted and restored via `ConfigPersister`, as well as included in mock/test data. (`AppliverySDK/Model/Config.swift` [[1]](diffhunk://#diff-e9d84bb2604a3ce004fade7dd0eb68758c5a5e29087f598d8da2ede484f7a839R38) `AppliverySDK/Data/Persisters/ConfigPersister.swift` [[2]](diffhunk://#diff-39278ad768135a476051fc6e26cd5c5cb58f2f78b0e03175b4a69ebeee05fc1fR19) [[3]](diffhunk://#diff-39278ad768135a476051fc6e26cd5c5cb58f2f78b0e03175b4a69ebeee05fc1fL62-R62) [[4]](diffhunk://#diff-39278ad768135a476051fc6e26cd5c5cb58f2f78b0e03175b4a69ebeee05fc1fR77) AppliveryBehaviorTests/MockData/ConfigMockData.swift [[5]](diffhunk://#diff-1b18a67fb58f1f1ccd9d14bbe5ade33a38c12bd5427cf20840fca42a7dd388ebL25-R26) AppliveryBehaviorTests/Mocks/ConfigServiceMock.swift [[6]](diffhunk://#diff-96769c275c7e18bfed6bd9a06966f00567e5da5438ef66b614d413493dd7a577L41-R42) AppliveryBehaviorTests/ServicesTests/UpdateServiceTests.swift [[7]](diffhunk://#diff-f6c9f0be47e3e78b7e1be63629053740a00819d1b289bab2bce006e02617ab9fL131-R132) [[8]](diffhunk://#diff-f6c9f0be47e3e78b7e1be63629053740a00819d1b289bab2bce006e02617ab9fL155-R157)

**SDK and Protocol Improvements:**
* Updated `UpdateError` to conform to `Error` and added new cases for disk space errors, enabling improved error handling and reporting for update/download operations. (`AppliverySDK/Applivery/AppliverySDK.swift` [[1]](diffhunk://#diff-f86d3e567fed0c23b2547250bbe6181e247a7794549efc32abd602e79511da51L44-R44) [[2]](diffhunk://#diff-f86d3e567fed0c23b2547250bbe6181e247a7794549efc32abd602e79511da51R64-R69)
* Introduced `SessionPersisterProtocol` and updated `LoginService` to depend on the protocol rather than the concrete type for better testability. (`AppliverySDK/Data/Persisters/SessionPersister.swift` [[1]](diffhunk://#diff-fff318f6ee5e21ef33442e72c6c464513c5a1e954f3baa6d5c90554558476fcaR21-R28) `AppliverySDK/Services/LoginService.swift` [[2]](diffhunk://#diff-07063ac10a6f5b5974497709cdf7284a1278e26efb098068c40d883b51e824eeL28-R28) [[3]](diffhunk://#diff-07063ac10a6f5b5974497709cdf7284a1278e26efb098068c40d883b51e824eeL43-R43)