### PR TITLE
Feature/apple 59 update readme docs and sdk comments docs

### DIFF
--- a/AppliverySDK/Applivery/AppliverySDK.swift
+++ b/AppliverySDK/Applivery/AppliverySDK.swift
@@ -303,14 +303,6 @@ public class AppliverySDK: NSObject, AppliveryService {
     }
 
     // MARK: - Instance Methods
-    /**
-     Starts Applivery's framework
-
-     - Parameters:
-     - token: Your App Token
-     - Since: 3.3
-     - Version: 3.3
-     */
     @objc public func start(
         token: String,
         tenant: String? = nil,
@@ -324,12 +316,6 @@ public class AppliverySDK: NSObject, AppliveryService {
         self.startInteractor.start(skipUpdateCheck: skipUpdateCheck)
     }
 
-    /**
-     Returns if application is updated to the latest version available
-
-     - Since: 3.1
-     - Version: 4.5
-     */
     @objc public func isUpToDate() -> Bool {
         var upToDate: Bool?
         let semaphore = DispatchSemaphore(value: 0)
@@ -346,36 +332,10 @@ public class AppliverySDK: NSObject, AppliveryService {
         return upToDate ?? true
     }
 
-    /**
-     Download newest build available
-
-     - Parameters:
-     - onDownload: Completion handler called when success/failure downloading the new version
-
-     - Attention: Be sure to call `start()` before this method.
-     - Since: 3.1
-     - Version: 4.5.0
-     */
     @objc public func update(onDownload: ((UpdateResult) -> Void)? = nil) {
         self.updateService.downloadLastBuild(onResult: onDownload)
     }
 
-    /**
-     Login a user
-
-     Programatically login a user in Applivery, for example if the app has a custom login and don't want to use Applivery's authentication to track the user in the platform
-
-     - Parameters:
-     - email: The user email. **Required**
-     - firstName: The first name of the user. **Optional**
-     - lastName: The last name of the user. **Optional**
-     - tags: A list of tags linked to the user with group / categorize purpose. **Optional**
-     - onComplete: Optional callback executed after binding the user. **Optional**
-
-     - SeeAlso: `unbindUser()`
-     - Since: 3.0
-     - Version: 4.5.0
-     */
     @objc public func bindUser(email: String, firstName: String? = nil, lastName: String? = nil, tags: [String]? = nil, onComplete: (() -> Void)? = nil) {
         let compactedTags = tags?.compactMap(removeEmpty) // Example: ["", "aaa", ""] -> ["aaa"]
         let user = User(
@@ -391,16 +351,6 @@ public class AppliverySDK: NSObject, AppliveryService {
         }
     }
 
-    /**
-     Get the currently bound user information
-
-     Retrieves the user information that was previously bound using `bindUser` method. Returns the user info as a dictionary if available, or nil if no user is currently bound.
-
-     - Parameter onSuccess: Callback with NSDictionary containing user info, or nil if no user is bound
-     - SeeAlso: `bindUser(email:firstname:lastname:tags)`
-     - Since: 4.5
-     - Version: 4.5
-     */
     @objc public func getUser(onSuccess: @escaping (NSDictionary?) -> Void) {
         guard let user = loginService.user else {
             logInfo("No user is currently bound")
@@ -411,85 +361,38 @@ public class AppliverySDK: NSObject, AppliveryService {
         onSuccess(user.dictionary() as NSDictionary)
     }
 
-    /**
-     Logout a previously binded user
-
-     Programatically logout a user in Applivery from a previous custom login.
-
-     - Parameter onComplete: Optional callback executed after unbinding the user. **Optional**
-     - SeeAlso: `bindUser(email:firstname:lastname:tags)`
-     - Since: 3.0
-     - Version: 3.0
-     */
     @objc public func unbindUser(onComplete: (() -> Void)? = nil) {
         self.loginService.unbindUser()
         onComplete?()
     }
 
-    /**
-     Present in a modal view the Applivery's feedback.
-
-     By default, Applivery will show a feedback formulary to your users when a screenshot is detected. If you want to do it programatically controlled by your app (for example in a shake event), you can call this method. Also you may want to prevent the feedback view to be show when a screenshot event is produced, for that you can call `disableFeedback()` method
-
-     - SeeAlso: `disableFeedback()`
-     - Since: 2.7
-     - Version: 2.7
-     */
     @objc public func feedbackEvent() {
         showFirstWindow()
         logInfo("Presenting feedback formulary")
         app.presentFeedbackForm()
     }
 
-    /**
-     Handles a given redirect URL as part of the SAML authentication flow.
-
-     When implementing SAML-based authentication, your app may receive a redirect URL
-     after the user completes their authentication on an external SAML identity provider.
-     By calling this method, you pass that redirect URL to `AppliverySafariManager` to
-     proceed with the final steps of the authentication flow.
-
-     - Parameter url: The redirect `URL` returned by the SAML provider.
-     - Since: 4.1.0
-     - Version: 4.1.0
-     */
+    
     @objc public func handleRedirectURL(url: URL) {
         let webview = AppliverySafariManager.shared
         webview.urlReceived(url: url)
     }
 
-    /**
-     - Parameter forceUpdate: The `forceUpdate`allows ignore or not the postponed time.
-     - Since: 4.1.0
-     - Version: 4.5.0
-     */
     @objc public func checkForUpdates(forceUpdate: Bool = false) {
         startInteractor.checkUpdate(forceUpdate: forceUpdate)
     }
 
-    /**
-     Disables listening for screenshot events to trigger the feedback action
-     - Since 4.5.0
-     - Version 4.5.0
-     */
+    
     @objc public func disableScreenshotFeedback() {
         logInfo("Disabled screenshot feedback")
         startInteractor.disableFeedback()
     }
-    /**
-     Enables the listener for screenshot events to trigger the feedback action
-     - Since 4.5.0
-     - Version 4.5.0
-     */
+
     @objc public func enableScreenshotFeedback() {
         logInfo("Enabled screenshot feedback")
         startInteractor.enableFeedback()
     }
-    /**
-     Enables checking for updates automatically when the app returns from background
-     - Since 4.5.0
-     - Version 4.5.0
-     */
+    
     @objc public func setCheckForUpdatesBackground(_ enabled: Bool) {
         updateService.setCheckForUpdatesBackground(enabled)
     }

--- a/AppliverySDK/Applivery/AppliverySDK.swift
+++ b/AppliverySDK/Applivery/AppliverySDK.swift
@@ -112,7 +112,7 @@ public typealias AppliveryLogHandler = @convention(block) (
 
  - SeeAlso: [Applivery's README on GitHub](https://github.com/applivery/applivery-ios-sdk/blob/master/README.md)
  - Since: 1.0
- - Version: 3.3
+ - Version: 4.5.0
  - Author: Alejandro Jiménez Agudo
  - Copyright: Applivery S.L.
  */
@@ -126,17 +126,6 @@ public class AppliverySDK: NSObject, AppliveryService {
     var window: AppliveryWindow?
 
     // MARK: Instance Properties
-    /**
-     Type of Applivery's logs you want displayed in the debug console
-
-     * **none**: No log will be shown. Recommended for production environments.
-     * **error**: Only warnings and errors. Recommended for develop environments.
-     * **info**: Errors and relevant information. Recommended for test integrating Applivery.
-     * **debug**: Request and Responses to Applivery's server will be displayed. Not recommended to use, only for debugging Applivery.
-
-     - Since: 1.0
-     - Version: 2.0
-     */
     @objc public var logLevel: LogLevel { didSet {
         self.globalConfig.logLevel = self.logLevel
     }}
@@ -147,108 +136,10 @@ public class AppliverySDK: NSObject, AppliveryService {
         self.globalConfig.logHandler = handler
     }
 
-    /**
-     Customize the SDK colors to fit your app
-
-     # Examples
-
-     You can create a new instance of `Palette` and assign it to this property
-
-     ```swift
-     Applivery.shared.palette = Palette(
-     primaryColor: .orange,
-     secondaryColor: .white,
-     primaryFontColor: .white,
-     secondaryFontColor: .black,
-     screenshotBrushColor: .green
-     )
-     ```
-
-     The SDK has Applivery's colors by default so, if you only need to change the primary color, yo can do this:
-
-     ```swift
-     Applivery.shared.palette = Palette(
-     primaryColor: .orange,
-     )
-     ```
-
-     Or even directly change the property
-
-     ```swift
-     Applivery.shared.palette.primaryColor = .orange
-     ```
-
-     - SeeAlso: `Palette`
-     - Since: 2.4
-     - Version: 2.4
-     */
     @objc public var palette: Palette { didSet {
         self.globalConfig.palette = self.palette
     }}
 
-    /**
-     Customize the SDK string literals to fit your app.
-
-     By default, Applivery has english literals.
-
-     # Examples
-
-     You can create a new instance of `TextLiterals` and assign it to this property
-
-     ```swift
-     Applivery.shared.textLiterals = TextLiterals(
-     appName: "Applivery",
-     alertButtonCancel: "Cancel",
-     alertButtonRetry: "Retry",
-     alertButtonOK: "OK",
-     errorUnexpected: "Unexpected error",
-     errorInvalidCredentials: "Invalid credentials",
-     errorDownloadURL: "Couldn't start download. Invalid url",
-     otaUpdateMessage: "There is a new version available for download. Do you want to update to the latest version?",
-     alertButtonLater: "Later",
-     alertButtonUpdate: "Update",
-     forceUpdateMessage: "Sorry this App is outdated. Please, update the App to continue using it",
-     buttonForceUpdate: "Update now",
-     feedbackButtonClose: "Close",
-     feedbackButtonAdd: "Add Feedback",
-     feedbackButtonSend: "Send Feedback",
-     feedbackSelectType: "Select type",
-     feedbackTypeBug: "Bug",
-     feedbackTypeFeedback: "Feedback",
-     feedbackMessagePlaceholder: "Add a message",
-     feedbackAttach: "Attach Screenshot",
-     loginInputUser: "user",
-     loginInputPassword: "password",
-     loginButton: "Login",
-     loginMessage: "Login is required!",
-     loginInvalidCredentials: "Wrong username or password, please, try again",
-     loginSessionExpired: "Your session has expired. Please, log in again"
-     )
-     ```
-
-     The SDK has literals by default so, if you only need to change the update messages, yo can do this:
-
-     ```swift
-     Applivery.shared.textLiterals = TextLiterals(
-     appName: "MyApp",
-     otaUpdateMessage: "There is a new version available for download. Do you want to update to the latest version?",
-     forceUpdateMessage: "Sorry this App is outdated. Please, update the App to continue using it"
-     )
-     ```
-
-     Or even directly change the property
-
-     ```swift
-     Applivery.shared.textLiterals.appName: "MyApp"
-     Applivery.shared.textLiterals.otaUpdateMessage: "There is a new version available for download. Do you want to update to the latest version?"
-     Applivery.shared.textLiterals.forceUpdateMessage: "Sorry this App is outdated. Please, update the App to continue using it"
-     ```
-
-     - Important: The default literals are only in english. Consider to set localized strings to fully support all languages your app does.
-     - SeeAlso: `TextLiterals`
-     - Since: 2.4
-     - Version: 2.4
-     */
     @objc public var textLiterals: TextLiterals { didSet {
         self.globalConfig.textLiterals = self.textLiterals
     }}
@@ -372,7 +263,6 @@ public class AppliverySDK: NSObject, AppliveryService {
         app.presentFeedbackForm()
     }
 
-    
     @objc public func handleRedirectURL(url: URL) {
         let webview = AppliverySafariManager.shared
         webview.urlReceived(url: url)
@@ -397,17 +287,6 @@ public class AppliverySDK: NSObject, AppliveryService {
         updateService.setCheckForUpdatesBackground(enabled)
     }
 }
-
-// MARK: - SDK Private methods
-private extension AppliverySDK {
-    func showFirstWindow() {
-        guard window != nil else {
-            window = AppliveryWindow(frame: UIScreen.main.bounds)
-            return
-        }
-    }
-}
-
 // MARK: - SDK Deprecated methods
 public extension AppliverySDK {
     /**
@@ -439,5 +318,14 @@ public extension AppliverySDK {
     @available(*, deprecated, renamed: "disableScreenshotFeedback()")
     @objc func disableFeedback() {
         self.startInteractor.disableFeedback()
+    }
+}
+// MARK: - SDK Private methods
+private extension AppliverySDK {
+    func showFirstWindow() {
+        guard window != nil else {
+            window = AppliveryWindow(frame: UIScreen.main.bounds)
+            return
+        }
     }
 }

--- a/AppliverySDK/Applivery/AppliveryService.swift
+++ b/AppliverySDK/Applivery/AppliveryService.swift
@@ -12,7 +12,6 @@ import Foundation
 /// - Since 4.5.0
 /// - Version 4.5.0
 @objc internal protocol AppliveryService: AnyObject {
-
     /**
      Type of Applivery's logs you want displayed in the debug console
 

--- a/AppliverySDK/Applivery/AppliveryService.swift
+++ b/AppliverySDK/Applivery/AppliveryService.swift
@@ -12,8 +12,120 @@ import Foundation
 /// - Since 4.5.0
 /// - Version 4.5.0
 @objc internal protocol AppliveryService: AnyObject {
+
+    /**
+     Type of Applivery's logs you want displayed in the debug console
+
+     * **none**: No log will be shown. Recommended for production environments.
+     * **error**: Only warnings and errors. Recommended for develop environments.
+     * **info**: Errors and relevant information. Recommended for test integrating Applivery.
+     * **debug**: Request and Responses to Applivery's server will be displayed. Not recommended to use, only for debugging Applivery.
+
+     - Since: 1.0
+     - Version: 2.0
+     */
     var logLevel: LogLevel { get set }
+
+    /**
+     Customize the SDK colors to fit your app
+
+     # Examples
+
+     You can create a new instance of `Palette` and assign it to this property
+
+     ```swift
+     Applivery.shared.palette = Palette(
+     primaryColor: .orange,
+     secondaryColor: .white,
+     primaryFontColor: .white,
+     secondaryFontColor: .black,
+     screenshotBrushColor: .green
+     )
+     ```
+
+     The SDK has Applivery's colors by default so, if you only need to change the primary color, yo can do this:
+
+     ```swift
+     Applivery.shared.palette = Palette(
+     primaryColor: .orange,
+     )
+     ```
+
+     Or even directly change the property
+
+     ```swift
+     Applivery.shared.palette.primaryColor = .orange
+     ```
+
+     - SeeAlso: `Palette`
+     - Since: 2.4
+     - Version: 2.4
+     */
     var palette: Palette { get set }
+
+    /**
+     Customize the SDK string literals to fit your app.
+
+     By default, Applivery has english literals.
+
+     # Examples
+
+     You can create a new instance of `TextLiterals` and assign it to this property
+
+     ```swift
+     Applivery.shared.textLiterals = TextLiterals(
+     appName: "Applivery",
+     alertButtonCancel: "Cancel",
+     alertButtonRetry: "Retry",
+     alertButtonOK: "OK",
+     errorUnexpected: "Unexpected error",
+     errorInvalidCredentials: "Invalid credentials",
+     errorDownloadURL: "Couldn't start download. Invalid url",
+     otaUpdateMessage: "There is a new version available for download. Do you want to update to the latest version?",
+     alertButtonLater: "Later",
+     alertButtonUpdate: "Update",
+     forceUpdateMessage: "Sorry this App is outdated. Please, update the App to continue using it",
+     buttonForceUpdate: "Update now",
+     feedbackButtonClose: "Close",
+     feedbackButtonAdd: "Add Feedback",
+     feedbackButtonSend: "Send Feedback",
+     feedbackSelectType: "Select type",
+     feedbackTypeBug: "Bug",
+     feedbackTypeFeedback: "Feedback",
+     feedbackMessagePlaceholder: "Add a message",
+     feedbackAttach: "Attach Screenshot",
+     loginInputUser: "user",
+     loginInputPassword: "password",
+     loginButton: "Login",
+     loginMessage: "Login is required!",
+     loginInvalidCredentials: "Wrong username or password, please, try again",
+     loginSessionExpired: "Your session has expired. Please, log in again"
+     )
+     ```
+
+     The SDK has literals by default so, if you only need to change the update messages, yo can do this:
+
+     ```swift
+     Applivery.shared.textLiterals = TextLiterals(
+     appName: "MyApp",
+     otaUpdateMessage: "There is a new version available for download. Do you want to update to the latest version?",
+     forceUpdateMessage: "Sorry this App is outdated. Please, update the App to continue using it"
+     )
+     ```
+
+     Or even directly change the property
+
+     ```swift
+     Applivery.shared.textLiterals.appName: "MyApp"
+     Applivery.shared.textLiterals.otaUpdateMessage: "There is a new version available for download. Do you want to update to the latest version?"
+     Applivery.shared.textLiterals.forceUpdateMessage: "Sorry this App is outdated. Please, update the App to continue using it"
+     ```
+
+     - Important: The default literals are only in english. Consider to set localized strings to fully support all languages your app does.
+     - SeeAlso: `TextLiterals`
+     - Since: 2.4
+     - Version: 2.4
+     */
     var textLiterals: TextLiterals { get set }
 
     func setLogHandler(_ handler: AppliveryLogHandler?)

--- a/AppliverySDK/Applivery/AppliveryService.swift
+++ b/AppliverySDK/Applivery/AppliveryService.swift
@@ -17,16 +17,130 @@ import Foundation
     var textLiterals: TextLiterals { get set }
 
     func setLogHandler(_ handler: AppliveryLogHandler?)
+    /**
+     Starts Applivery's framework
+
+     - Parameters:
+     - token: Your App Token
+     - Since: 3.3
+     - Version: 3.3
+     */
     func start(token: String, tenant: String?, configuration: AppliveryConfiguration, skipUpdateCheck: Bool)
+
+    /**
+     Returns if application is updated to the latest version available
+
+     - Since: 3.1
+     - Version: 4.5
+     */
     func isUpToDate() -> Bool
+
+    /**
+     Download newest build available
+
+     - Parameters:
+     - onDownload: Completion handler called when success/failure downloading the new version
+
+     - Attention: Be sure to call `start()` before this method.
+     - Since: 3.1
+     - Version: 4.5.0
+     */
     func update(onDownload: ((UpdateResult) -> Void)?)
+
+    /**
+     Login a user
+
+     Programatically login a user in Applivery, for example if the app has a custom login and don't want to use Applivery's authentication to track the user in the platform
+
+     - Parameters:
+     - email: The user email. **Required**
+     - firstName: The first name of the user. **Optional**
+     - lastName: The last name of the user. **Optional**
+     - tags: A list of tags linked to the user with group / categorize purpose. **Optional**
+     - onComplete: Optional callback executed after binding the user. **Optional**
+
+     - SeeAlso: `unbindUser()`
+     - Since: 3.0
+     - Version: 4.5.0
+     */
     func bindUser(email: String, firstName: String?, lastName: String?, tags: [String]?, onComplete: (() -> Void)?)
+
+    /**
+     Logout a previously binded user
+
+     Programatically logout a user in Applivery from a previous custom login.
+
+     - Parameter onComplete: Optional callback executed after unbinding the user. **Optional**
+     - SeeAlso: `bindUser(email:firstname:lastname:tags)`
+     - Since: 3.0
+     - Version: 3.0
+     */
     func unbindUser(onComplete: (() -> Void)?)
+
+    /**
+     Get the currently bound user information
+
+     Retrieves the user information that was previously bound using `bindUser` method. Returns the user info as a dictionary if available, or nil if no user is currently bound.
+
+     - Parameter onSuccess: Callback with NSDictionary containing user info, or nil if no user is bound
+     - SeeAlso: `bindUser(email:firstname:lastname:tags)`
+     - Since: 4.5
+     - Version: 4.5
+     */
     func getUser(onSuccess: @escaping (NSDictionary?) -> Void)
+
+    /**
+     Present in an alert view the Applivery's feedback.
+
+     By default, Applivery will show a feedback formulary to your users when a screenshot is detected. If you want to do it programatically controlled by your app (for example in a shake event), you can call this method. Also you may want to prevent the feedback view to be show when a screenshot event is produced, for that you can call `disableFeedback()` method
+
+     - SeeAlso: `disableFeedback()`
+     - Since: 2.7
+     - Version: 4.5.0
+     */
     func feedbackEvent()
+
+    /**
+     Handles a given redirect URL as part of the SAML authentication flow.
+
+     When implementing SAML-based authentication, your app may receive a redirect URL
+     after the user completes their authentication on an external SAML identity provider.
+     By calling this method, you pass that redirect URL to `AppliverySafariManager` to
+     proceed with the final steps of the authentication flow.
+
+     - Parameter url: The redirect `URL` returned by the SAML provider.
+     - Since: 4.1.0
+     - Version: 4.1.0
+     */
     func handleRedirectURL(url: URL)
+
+    /**
+     Checks if updates are available and launches the update flow if they are
+
+     - Parameter forceUpdate: The `forceUpdate`allows ignore or not the postponed time.
+     - Since: 4.1.0
+     - Version: 4.5.0
+     */
     func checkForUpdates(forceUpdate: Bool)
+
+    /**
+     Disables listening for screenshot events to trigger the feedback action
+     - Since 4.5.0
+     - Version 4.5.0
+     */
     func disableScreenshotFeedback()
+
+    /**
+     Enables the listener for screenshot events to trigger the feedback action
+     - Since 4.5.0
+     - Version 4.5.0
+     */
     func enableScreenshotFeedback()
+
+    /**
+     Enables checking for updates automatically when the app returns from background
+     - Since 4.5.0
+     - Version 4.5.0
+     */
     func setCheckForUpdatesBackground(_ enabled: Bool)
 }

--- a/AppliverySDKTests/.swiftlint.yml
+++ b/AppliverySDKTests/.swiftlint.yml
@@ -1,7 +1,0 @@
-disabled_rules: # rule identifiers to exclude from running
-  - type_body_length
-  - line_length
-  - file_length
-  - force_try
-  - trailing_whitespace
-  - vertical_whitespace

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ project '<Your Project Name>.xcodeproj'
 # platform :ios, '11.0'
 # use_frameworks!  # Starting from v3.2 you can use applivery as a static framework, leave this line commented if you wish
 target '<Your Target Name>' do
-  pod 'Applivery', '~> 3.3'
+  pod 'Applivery', '~> 4.5'
 end
 ```
 
@@ -218,6 +218,112 @@ The compatibility version is as follow:
 | **v3.4**          | 13.x          | 5.X           |
 | **v4.0**          | 13.x          | 5.X           |
 | **v4.0.x**        | 13.x          | 5.X           |
+
+
+# AppliveryService Protocol (SDK API)
+
+The `AppliveryService` protocol defines the core interface for interacting with the Applivery iOS SDK. It is implemented by `AppliverySDK.shared` and provides all the main configuration, update, feedback, and user management features. This protocol is available since version 4.5.0.
+
+## Overview
+
+`AppliveryService` exposes properties and methods to:
+
+- Control log verbosity (`logLevel`)
+- Customize SDK appearance (`palette`)
+- Localize SDK strings (`textLiterals`)
+- Start the SDK and configure it (`start`)
+- Check for updates and trigger update flows
+- Bind/unbind users for analytics and feedback
+- Present feedback UI
+- Handle SAML authentication redirects
+- Enable/disable screenshot feedback
+- Control update checks in background
+
+## Properties
+
+| Property      | Type         | Description |
+|-------------- | ------------ | ----------- |
+| `logLevel`    | `LogLevel`   | Controls the verbosity of Applivery logs. See [Logs and debugging](#logs-and-debugging) for details. |
+| `palette`     | `Palette`    | Customize SDK UI colors. See [Customize SDK's colors](#customize-sdks-colors). |
+| `textLiterals`| `TextLiterals` | Customize SDK string literals. See [Customize string literals](#customize-string-literals). |
+
+## Methods
+
+### setLogHandler(_ handler: AppliveryLogHandler?)
+Set a custom log handler to capture or redirect Applivery logs. See [Custom Log Handler](#custom-log-handler).
+
+### start(token: String, tenant: String?, configuration: AppliveryConfiguration, skipUpdateCheck: Bool)
+Starts the Applivery SDK. Call this early in your app's lifecycle.
+
+**Parameters:**
+- `token`: Your App Token (required)
+- `tenant`: Tenant identifier (optional)
+- `configuration`: `AppliveryConfiguration` object (see [AppliveryConfiguration](#appliveryconfiguration))
+- `skipUpdateCheck`: If true, skips the initial update check
+
+### isUpToDate() -> Bool
+Returns whether the app is up to date with the latest version available.
+
+### update(onDownload: ((UpdateResult) -> Void)?)
+Downloads and installs the newest build available. Call after `start()`.
+
+### bindUser(email: String, firstName: String?, lastName: String?, tags: [String]?, onComplete: (() -> Void)?)
+Programmatically log in a user for analytics and feedback tracking.
+
+### unbindUser(onComplete: (() -> Void)?)
+Logs out a previously bound user.
+
+### getUser(onSuccess: @escaping (NSDictionary?) -> Void)
+Retrieves the currently bound user information as a dictionary, or nil if no user is bound.
+
+### feedbackEvent()
+Presents the Applivery feedback UI (form for bug reports, suggestions, etc). You can call this programmatically (e.g., on shake gesture).
+
+### handleRedirectURL(url: URL)
+Handles a redirect URL as part of the SAML authentication flow. See [Handling SAML Redirect URLs](#handling-saml-redirect-urls).
+
+### checkForUpdates(forceUpdate: Bool)
+Checks for updates and launches the update flow if available. `forceUpdate` ignores postponed time if true.
+
+### disableScreenshotFeedback()
+Disables listening for screenshot events to trigger feedback.
+
+### enableScreenshotFeedback()
+Enables listening for screenshot events to trigger feedback.
+
+### setCheckForUpdatesBackground(_ enabled: Bool)
+Enables or disables automatic update checks when the app returns from background.
+
+## Example Usage
+
+```swift
+import Applivery
+
+let applivery: AppliveryService = AppliverySDK.shared
+applivery.logLevel = .info
+applivery.palette = Palette(primaryColor: .orange)
+applivery.textLiterals = TextLiterals(appName: "MyApp")
+
+applivery.setLogHandler { message, level, filename, line, funcname in
+    print("[Applivery]", message)
+}
+
+applivery.start(token: "YOUR_TOKEN", tenant: nil, configuration: AppliveryConfiguration(), skipUpdateCheck: false)
+
+if !applivery.isUpToDate() {
+    applivery.update { result in
+        // handle update result
+    }
+}
+
+applivery.bindUser(email: "user@email.com", firstName: "John", lastName: "Doe", tags: ["beta"], onComplete: nil)
+applivery.getUser { userInfo in
+    print(userInfo)
+}
+applivery.feedbackEvent()
+```
+
+For more details, see the [AppliveryService protocol documentation](./AppliverySDK/Applivery/AppliveryService.swift).
 
 # Advanced concepts
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 ![Version](https://img.shields.io/badge/version-4.1.0-blue.svg)
 ![Minimum iOS Version](https://img.shields.io/badge/iOS-15.0%2B-blue.svg)
 ![Language](https://img.shields.io/badge/Language-Swift-orange.svg)
-[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![CocoaPods Compatible](https://img.shields.io/cocoapods/v/Applivery.svg)](https://cocoapods.org/pods/Applivery)
 [![Fastlane Plugin](https://img.shields.io/badge/Fastlane_Plugin-available-brightgreen.svg)](https://github.com/fastlane-community/fastlane-plugin-applivery)
 [![Twitter](https://img.shields.io/badge/twitter-@Applivery-blue.svg?style=flat)](https://twitter.com/Applivery)
@@ -19,7 +18,6 @@
 - [Getting Started](#getting-started)
 - [SDK Installation](#sdk-installation)
   - [Using SwiftPM](#using-swift-package-manager)
-  - [Using Carthage](#using-carthage)
   - [Using CocoaPods](#using-cocoapods)
   - [Manual installation](#manual-installation)
   - [Objective-C](#objective-c)
@@ -131,29 +129,9 @@ You can find a tutorial about dynamically excluding Applivery for an AppStore sc
 
 ### Troubleshooting
 
-Beware if you are using a script for removing simulator slices of dynamic frameworks [like this](https://github.com/applivery/applivery-ios-sdk/blob/master/script/applivery_script.sh). Xcode only build the framework for the configuration selected, so when archiving a release configuration, no simulator slice is generated inside the framework and the script may fail or remove the applivery framework itself. You should ignore AppliveryDynamic in this kind of scripts (commonly used with carthage)
+Beware if you are using a script for removing simulator slices of dynamic frameworks [like this](https://github.com/applivery/applivery-ios-sdk/blob/master/script/applivery_script.sh). Xcode only build the framework for the configuration selected, so when archiving a release configuration, no simulator slice is generated inside the framework and the script may fail or remove the applivery framework itself. You should ignore AppliveryDynamic in this kind of scripts
 
 ---
-
-### Using Carthage
-
-(deprecated)
-
-Install carthage with using brew
-
-```bash
-brew update && brew install carthage
-```
-
-Add the following line to your's Cartfile
-
-```bash
-github "applivery/applivery-ios-sdk" ~> 3.3
-```
-
-Run `carthage update` and then drag the built framework into your project.
-
-More info about Carthage [here](https://github.com/Carthage/Carthage#installing-carthage).
 
 ### Using CocoaPods
 
@@ -442,8 +420,6 @@ AppliverySDK.shared.textLiterals.forceUpdateMessage: "Sorry this App is outdated
 _**Important**_: The default literals are only in english. Consider to set localized strings to fully support all languages your app does.
 
 ## Embedded frameworks & ipa generation
-
-If you have installed the SDK with Carthage and as a Dynamic framework, Applivery.framework is built as a fat universal library, that means that you can compile for devices or simulator without any problem, but you can not make an ipa file if it has inside an embedded framework with simulator slices.
 
 In this case, the solution is as simple as add [this script](https://github.com/applivery/applivery-ios-sdk/blob/master/script/applivery_script.sh) in "New Run Script Phase".
 You'll find inside _Build Phases_ tab.


### PR DESCRIPTION
This pull request primarily focuses on improving the documentation and code organization of the `AppliverySDK` by moving detailed property and method documentation from the implementation file (`AppliverySDK.swift`) into the protocol definition (`AppliveryService.swift`). Additionally, it removes Carthage support references from the documentation and makes minor cleanup improvements.

Key changes include:

**Documentation Refactoring and Consistency:**
- Moved all major property and method documentation comments from the `AppliverySDK.swift` implementation file to the `AppliveryService.swift` protocol, ensuring that the protocol now serves as the single source of truth for SDK documentation. This makes the codebase cleaner and keeps documentation closer to the API definition. [[1]](diffhunk://#diff-f86d3e567fed0c23b2547250bbe6181e247a7794549efc32abd602e79511da51L129-L139) [[2]](diffhunk://#diff-f86d3e567fed0c23b2547250bbe6181e247a7794549efc32abd602e79511da51L150-L251) [[3]](diffhunk://#diff-f86d3e567fed0c23b2547250bbe6181e247a7794549efc32abd602e79511da51L306-L313) [[4]](diffhunk://#diff-f86d3e567fed0c23b2547250bbe6181e247a7794549efc32abd602e79511da51L327-L332) [[5]](diffhunk://#diff-f86d3e567fed0c23b2547250bbe6181e247a7794549efc32abd602e79511da51L349-L378) [[6]](diffhunk://#diff-f86d3e567fed0c23b2547250bbe6181e247a7794549efc32abd602e79511da51L394-L403) [[7]](diffhunk://#diff-f86d3e567fed0c23b2547250bbe6181e247a7794549efc32abd602e79511da51L414-L507) [[8]](diffhunk://#diff-56f396b80ba2ad1689f45cb80fc8494932a6e3c06e2bd5c61a761975936ab023R15-R255)

**SDK Versioning and Metadata:**
- Updated the SDK version in documentation comments from `3.3` to `4.5.0`, reflecting the current release version.

**Carthage Support Removal:**
- Removed all references to Carthage from the `README.md`, including badges and installation instructions, indicating that Carthage is no longer officially supported. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L6) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L22)

**Code Organization and Cleanup:**
- Moved the `showFirstWindow` private method to the appropriate private extension section at the end of `AppliverySDK.swift` for better code organization. [[1]](diffhunk://#diff-f86d3e567fed0c23b2547250bbe6181e247a7794549efc32abd602e79511da51L414-L507) [[2]](diffhunk://#diff-f86d3e567fed0c23b2547250bbe6181e247a7794549efc32abd602e79511da51R323-R331)

These changes improve maintainability, documentation consistency, and clarify the SDK's current supported installation methods.