### PR TITLE
Release/4.5.2

### DIFF
--- a/Applivery.podspec
+++ b/Applivery.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                = "Applivery"
-  s.version             = "4.5.0"
+  s.version             = "4.5.2"
   s.summary             = "Mobile App Distribution"
   s.homepage            = "https://www.applivery.com"
   s.license             = { :type => "MIT", :file => "LICENSE" }

--- a/AppliveryBehaviorTests/MockData/ConfigMockData.swift
+++ b/AppliveryBehaviorTests/MockData/ConfigMockData.swift
@@ -9,7 +9,6 @@ import Foundation
 @testable import Applivery
 
 struct ConfigMockData {
-    
     static let config = Config(
         status: true,
         data: ConfigData(
@@ -32,5 +31,19 @@ struct ConfigMockData {
             name: "TestConfig",
             description: "This is a test config"
         )
+    )
+}
+
+extension SDKData {
+    static let mock = Self.init(
+        minVersion: "1.0.0",
+        forceUpdate: true,
+        lastBuildId: "some-build-id",
+        mustUpdateMsg: nil,
+        ota: false,
+        lastBuildVersion: nil,
+        updateMsg: nil,
+        forceAuth: false,
+        lastBuildSize: 5000000000
     )
 }

--- a/AppliveryBehaviorTests/MockData/ConfigMockData.swift
+++ b/AppliveryBehaviorTests/MockData/ConfigMockData.swift
@@ -22,7 +22,8 @@ struct ConfigMockData {
                     ota: true,
                     lastBuildVersion: "1.0.1",
                     updateMsg: "Update available",
-                    forceAuth: false
+                    forceAuth: false,
+                    lastBuildSize: 300000000
                 )
             ),
             id: "configId",

--- a/AppliveryBehaviorTests/Mocks/AppMock.swift
+++ b/AppliveryBehaviorTests/Mocks/AppMock.swift
@@ -18,6 +18,7 @@ class AppMock: AppProtocol {
     var stubVersionName: String = "NO VERSION SET"
     var stubLanguage: String = "NO LANGUAGE SET"
     var stubOpenUrlResult = false
+    var stubDeviceAvailableSpace: Int64 = 100_000_000_000 // default 100GB
 
     // Outputs
     var spyOpenUrl = (called: false, url: "")
@@ -121,5 +122,9 @@ class AppMock: AppProtocol {
         if let firstOption = options.first {
             selectionHandler(firstOption)
         }
+    }
+
+    func deviceAvailableSpace() throws -> Int64 {
+        return stubDeviceAvailableSpace
     }
 }

--- a/AppliveryBehaviorTests/Mocks/ConfigServiceMock.swift
+++ b/AppliveryBehaviorTests/Mocks/ConfigServiceMock.swift
@@ -38,7 +38,8 @@ final class ConfigServiceMock: ConfigServiceProtocol {
                 ota: false,
                 lastBuildVersion: nil,
                 updateMsg: nil,
-                forceAuth: false
+                forceAuth: false,
+                lastBuildSize: nil
             )
             let sdk = SDK(ios: sdkData)
             let configData = ConfigData(

--- a/AppliveryBehaviorTests/Mocks/DownloadServiceMock.swift
+++ b/AppliveryBehaviorTests/Mocks/DownloadServiceMock.swift
@@ -1,0 +1,26 @@
+//
+//  DownloadServiceMock.swift
+//  AppliverySDK
+//
+//  Created by Abigail Dominguez Morlans on 30/9/25.
+//  Copyright © 2025 Applivery S.L. All rights reserved.
+//
+
+@testable import Applivery
+
+class DownloadServiceMock: DownloadServiceProtocol {
+    var stubbedToken: DownloadToken?
+    var stubbedURL: String?
+    var fetchDownloadTokenCalled = false
+    var downloadURLCalled = false
+
+    func fetchDownloadToken(with buildId: String) async -> DownloadToken? {
+        fetchDownloadTokenCalled = true
+        return stubbedToken
+    }
+
+    func downloadURL(_ lastBuildId: String) async -> String? {
+        downloadURLCalled = true
+        return stubbedURL
+    }
+}

--- a/AppliveryBehaviorTests/Mocks/LoginRepositoryMock.swift
+++ b/AppliveryBehaviorTests/Mocks/LoginRepositoryMock.swift
@@ -1,0 +1,23 @@
+//
+//  LoginRepositoryMock.swift
+//  AppliverySDK
+//
+//  Created by Abigail Dominguez Morlans on 30/9/25.
+//  Copyright © 2025 Applivery S.L. All rights reserved.
+//
+
+import Foundation
+@testable import Applivery
+
+class LoginRepositoryMock: LoginRepositoryProtocol {
+    var shouldSucceed = false
+    var shouldReturn401 = false
+    func login(loginData: LoginData) async throws -> AccessToken {
+        if shouldReturn401 { throw APIError.statusCode(401) }
+        if shouldSucceed { return AccessToken(token: "token") }
+        throw APIError.statusCode(500)
+    }
+    func bind(user: User) async throws -> CustomLogin { fatalError() }
+    func getRedirctURL() async throws -> URL? { return URL(string: "https://applivery.com") }
+    func unbindUser() {}
+}

--- a/AppliveryBehaviorTests/Mocks/MockSessionPersister.swift
+++ b/AppliveryBehaviorTests/Mocks/MockSessionPersister.swift
@@ -1,0 +1,34 @@
+//
+//  MockSessionPersister.swift
+//  AppliverySDK
+//
+//  Created by Abigail Dominguez Morlans on 30/9/25.
+//  Copyright © 2025 Applivery S.L. All rights reserved.
+//
+
+@testable import Applivery
+
+class MockSessionPersister: SessionPersisterProtocol {
+    var savedUserName: String?
+    var didSaveUserName = false
+    var userNameToLoad: String = ""
+    var accessTokenToLoad: AccessToken? = nil
+
+    func loadAccessToken() -> AccessToken? {
+        return accessTokenToLoad
+    }
+
+    func saveUserName(userName: String) {
+        didSaveUserName = true
+        savedUserName = userName
+    }
+
+    func loadUserName() -> String {
+        return userNameToLoad
+    }
+
+    func removeUser() {
+        userNameToLoad = ""
+        savedUserName = nil
+    }
+}

--- a/AppliveryBehaviorTests/Mocks/MockUpdateService.swift
+++ b/AppliveryBehaviorTests/Mocks/MockUpdateService.swift
@@ -41,7 +41,7 @@ class MockUpdateService: UpdateServiceProtocol {
         }
     }
 
-    func isUpToDate() -> Bool {
+    func isUpToDate() async throws -> Bool {
         return isUpToDateResponse
     }
 
@@ -49,7 +49,7 @@ class MockUpdateService: UpdateServiceProtocol {
         return checkForceUpdateResponse
     }
 
-    func checkOtaUpdate(_ config: SDKData?, buildNumber: String) -> Bool {
+    func checkOtaUpdate(_ config: SDKData?, version: String, buildNumber: String) -> Bool {
         return checkOtaUpdateResponse
     }
 

--- a/AppliveryBehaviorTests/Mocks/MockUpdateService.swift
+++ b/AppliveryBehaviorTests/Mocks/MockUpdateService.swift
@@ -49,7 +49,7 @@ class MockUpdateService: UpdateServiceProtocol {
         return checkForceUpdateResponse
     }
 
-    func checkOtaUpdate(_ config: SDKData?, version: String) -> Bool {
+    func checkOtaUpdate(_ config: SDKData?, buildNumber: String) -> Bool {
         return checkOtaUpdateResponse
     }
 

--- a/AppliveryBehaviorTests/Mocks/MockUpdateService.swift
+++ b/AppliveryBehaviorTests/Mocks/MockUpdateService.swift
@@ -45,11 +45,11 @@ class MockUpdateService: UpdateServiceProtocol {
         return isUpToDateResponse
     }
 
-    func checkForceUpdate(_ config: SDKData?, version: String) -> Bool {
+    func checkForceUpdate(_ config: SDKData?, buildNumber: String) -> Bool {
         return checkForceUpdateResponse
     }
 
-    func checkOtaUpdate(_ config: SDKData?, version: String, buildNumber: String) -> Bool {
+    func checkOtaUpdate(_ config: SDKData?, buildNumber: String) -> Bool {
         return checkOtaUpdateResponse
     }
 

--- a/AppliveryBehaviorTests/Mocks/UpdateInteractoMock.swift
+++ b/AppliveryBehaviorTests/Mocks/UpdateInteractoMock.swift
@@ -42,7 +42,7 @@ class UpdateServiceMock: UpdateServiceProtocol {
         }
     }
 
-    func isUpToDate() -> Bool {
+    func isUpToDate() async throws -> Bool {
         return isUpToDateResponse
     }
 
@@ -50,7 +50,7 @@ class UpdateServiceMock: UpdateServiceProtocol {
         return checkForceUpdateResponse
     }
 
-    func checkOtaUpdate(_ config: SDKData?, buildNumber: String) -> Bool {
+    func checkOtaUpdate(_ config: SDKData?, version: String, buildNumber: String) -> Bool {
         return checkOtaUpdateResponse
     }
 

--- a/AppliveryBehaviorTests/Mocks/UpdateInteractoMock.swift
+++ b/AppliveryBehaviorTests/Mocks/UpdateInteractoMock.swift
@@ -50,7 +50,7 @@ class UpdateServiceMock: UpdateServiceProtocol {
         return checkForceUpdateResponse
     }
 
-    func checkOtaUpdate(_ config: SDKData?, version: String) -> Bool {
+    func checkOtaUpdate(_ config: SDKData?, buildNumber: String) -> Bool {
         return checkOtaUpdateResponse
     }
 

--- a/AppliveryBehaviorTests/Mocks/UpdateInteractoMock.swift
+++ b/AppliveryBehaviorTests/Mocks/UpdateInteractoMock.swift
@@ -46,11 +46,11 @@ class UpdateServiceMock: UpdateServiceProtocol {
         return isUpToDateResponse
     }
 
-    func checkForceUpdate(_ config: SDKData?, version: String) -> Bool {
+    func checkForceUpdate(_ config: SDKData?, buildNumber: String) -> Bool {
         return checkForceUpdateResponse
     }
 
-    func checkOtaUpdate(_ config: SDKData?, version: String, buildNumber: String) -> Bool {
+    func checkOtaUpdate(_ config: SDKData?, buildNumber: String) -> Bool {
         return checkOtaUpdateResponse
     }
 

--- a/AppliveryBehaviorTests/ServicesTests/LoginServiceTests.swift
+++ b/AppliveryBehaviorTests/ServicesTests/LoginServiceTests.swift
@@ -1,0 +1,262 @@
+//
+//  LoginServiceTests.swift
+//  AppliverySDK
+//
+//  Created by Abigail Dominguez Morlans on 30/9/25.
+//  Copyright © 2025 Applivery S.L. All rights reserved.
+//
+
+import Testing
+@testable import Applivery
+
+struct LoginServiceTests {
+    @Test
+    func testLoginSuccess() async throws {
+        let loginRepository = LoginRepositoryMock()
+        let configService = ConfigServiceMock()
+        let downloadService = DownloadServiceMock()
+        let globalConfig = GlobalConfig.shared
+        let sessionPersister = MockSessionPersister()
+        let app = AppMock()
+        let keychain = MockKeychainManager()
+        let forceUpdateConfig = UpdateConfigResponse(
+            config: SDKData(
+                minVersion: "1.0.0",
+                forceUpdate: true,
+                lastBuildId: "some-build-id",
+                mustUpdateMsg: nil,
+                ota: false,
+                lastBuildVersion: nil,
+                updateMsg: nil,
+                forceAuth: false,
+                lastBuildSize: 5000000000
+            ),
+            version: "0.9.0",
+            buildNumber: "100"
+        )
+        configService.currentConfigResponse = forceUpdateConfig
+        let loginService = LoginService(
+            loginRepository: loginRepository,
+            configService: configService,
+            downloadService: downloadService,
+            globalConfig: globalConfig,
+            sessionPersister: sessionPersister,
+            app: app,
+            keychain: keychain
+        )
+        loginRepository.shouldSucceed = true
+        let loginData = LoginData(provider: "provider", payload: .init(user: "test@applivery.com", password: "pass"))
+        await loginService.login(loginData: loginData)
+        #expect(sessionPersister.didSaveUserName)
+    }
+
+    @Test
+    func testLoginFailure401() async {
+        let loginRepository = LoginRepositoryMock()
+        let configService = ConfigServiceMock()
+        let downloadService = DownloadServiceMock()
+        let globalConfig = GlobalConfig.shared
+        let sessionPersister = MockSessionPersister()
+        let app = AppMock()
+        let keychain = MockKeychainManager()
+        let forceUpdateConfig = UpdateConfigResponse(
+            config: SDKData(
+                minVersion: "1.0.0",
+                forceUpdate: true,
+                lastBuildId: "some-build-id",
+                mustUpdateMsg: nil,
+                ota: false,
+                lastBuildVersion: nil,
+                updateMsg: nil,
+                forceAuth: false,
+                lastBuildSize: 5000000000
+            ),
+            version: "0.9.0",
+            buildNumber: "100"
+        )
+        configService.currentConfigResponse = forceUpdateConfig
+        let loginService = LoginService(
+            loginRepository: loginRepository,
+            configService: configService,
+            downloadService: downloadService,
+            globalConfig: globalConfig,
+            sessionPersister: sessionPersister,
+            app: app,
+            keychain: keychain
+        )
+        loginRepository.shouldReturn401 = true
+        let loginData = LoginData(provider: "provider", payload: .init(user: "test@applivery.com", password: "pass"))
+        await loginService.login(loginData: loginData)
+        // No assertion for SafariManager side effect since it is now a noop
+    }
+
+    @Test
+    func testRequestAuthorizationWithToken() async {
+        let loginRepository = LoginRepositoryMock()
+        let configService = ConfigServiceMock()
+        let downloadService = DownloadServiceMock()
+        let globalConfig = GlobalConfig.shared
+        let sessionPersister = MockSessionPersister()
+        let app = AppMock()
+        let keychain = MockKeychainManager()
+        let forceUpdateConfig = UpdateConfigResponse(
+            config: SDKData(
+                minVersion: "1.0.0",
+                forceUpdate: true,
+                lastBuildId: "some-build-id",
+                mustUpdateMsg: nil,
+                ota: false,
+                lastBuildVersion: nil,
+                updateMsg: nil,
+                forceAuth: false,
+                lastBuildSize: 5000000000
+            ),
+            version: "0.9.0",
+            buildNumber: "100"
+        )
+        configService.currentConfigResponse = forceUpdateConfig
+        let loginService = LoginService(
+            loginRepository: loginRepository,
+            configService: configService,
+            downloadService: downloadService,
+            globalConfig: globalConfig,
+            sessionPersister: sessionPersister,
+            app: app,
+            keychain: keychain
+        )
+        // Ensure bundle ID is set before storing the token
+        app.stubBundleID = "com.applivery.test"
+        try? keychain.store("token", for: app.stubBundleID)
+        downloadService.stubbedURL = "https://applivery.com/app.ipa"
+        var downloadCalled = false
+        loginService.requestAuthorization(onResult: { _ in downloadCalled = true })
+        waitUntil { downloadService.downloadURLCalled && downloadCalled }
+        #expect(downloadService.downloadURLCalled)
+        #expect(downloadCalled)
+    }
+
+    @Test
+    func testRequestAuthorizationWithoutToken() async {
+        let loginRepository = LoginRepositoryMock()
+        let configService = ConfigServiceMock()
+        let downloadService = DownloadServiceMock()
+        let globalConfig = GlobalConfig.shared
+        let sessionPersister = MockSessionPersister()
+        let app = AppMock()
+        let keychain = MockKeychainManager()
+        let forceUpdateConfig = UpdateConfigResponse(
+            config: SDKData(
+                minVersion: "1.0.0",
+                forceUpdate: true,
+                lastBuildId: "some-build-id",
+                mustUpdateMsg: nil,
+                ota: false,
+                lastBuildVersion: nil,
+                updateMsg: nil,
+                forceAuth: false,
+                lastBuildSize: 5000000000
+            ),
+            version: "0.9.0",
+            buildNumber: "100"
+        )
+        configService.currentConfigResponse = forceUpdateConfig
+        let loginService = LoginService(
+            loginRepository: loginRepository,
+            configService: configService,
+            downloadService: downloadService,
+            globalConfig: globalConfig,
+            sessionPersister: sessionPersister,
+            app: app,
+            keychain: keychain
+        )
+        try? keychain.remove(for: "com.applivery.test")
+        var result: UpdateResult?
+        loginService.requestAuthorization { r in result = r }
+        waitUntil { result != nil }
+        #expect(result == .failure(error: .authRequired))
+    }
+
+    @Test
+    func testDownloadInsufficientDiskSpace() async {
+        let loginRepository = LoginRepositoryMock()
+        let configService = ConfigServiceMock()
+        let downloadService = DownloadServiceMock()
+        let globalConfig = GlobalConfig.shared
+        let sessionPersister = MockSessionPersister()
+        let app = AppMock()
+        let keychain = MockKeychainManager()
+        let forceUpdateConfig = UpdateConfigResponse(
+            config: SDKData(
+                minVersion: "1.0.0",
+                forceUpdate: true,
+                lastBuildId: "some-build-id",
+                mustUpdateMsg: nil,
+                ota: false,
+                lastBuildVersion: nil,
+                updateMsg: nil,
+                forceAuth: false,
+                lastBuildSize: 5000000000
+            ),
+            version: "0.9.0",
+            buildNumber: "100"
+        )
+        configService.currentConfigResponse = forceUpdateConfig
+        let loginService = LoginService(
+            loginRepository: loginRepository,
+            configService: configService,
+            downloadService: downloadService,
+            globalConfig: globalConfig,
+            sessionPersister: sessionPersister,
+            app: app,
+            keychain: keychain
+        )
+        downloadService.stubbedURL = nil
+        var result: UpdateResult?
+        loginService.download { r in result = r }
+        waitUntil { result != nil }
+        #expect(result == .failure(error: .noDiskSpaceAvailable))
+    }
+
+    @Test
+    func testDownloadSufficientDiskSpace() async {
+        let loginRepository = LoginRepositoryMock()
+        let configService = ConfigServiceMock()
+        let downloadService = DownloadServiceMock()
+        let globalConfig = GlobalConfig.shared
+        let sessionPersister = MockSessionPersister()
+        let app = AppMock()
+        let keychain = MockKeychainManager()
+        let forceUpdateConfig = UpdateConfigResponse(
+            config: SDKData(
+                minVersion: "1.0.0",
+                forceUpdate: true,
+                lastBuildId: "some-build-id",
+                mustUpdateMsg: nil,
+                ota: false,
+                lastBuildVersion: nil,
+                updateMsg: nil,
+                forceAuth: false,
+                lastBuildSize: 5000000000
+            ),
+            version: "0.9.0",
+            buildNumber: "100"
+        )
+        configService.currentConfigResponse = forceUpdateConfig
+        let loginService = LoginService(
+            loginRepository: loginRepository,
+            configService: configService,
+            downloadService: downloadService,
+            globalConfig: globalConfig,
+            sessionPersister: sessionPersister,
+            app: app,
+            keychain: keychain
+        )
+        downloadService.stubbedURL = "https://applivery.com/app.ipa"
+        var result: UpdateResult?
+        loginService.download { r in result = r }
+        waitUntil { result != nil && downloadService.downloadURLCalled }
+
+        #expect(result?.type == .success)
+        #expect(downloadService.downloadURLCalled)
+    }
+}

--- a/AppliveryBehaviorTests/ServicesTests/LoginServiceTests.swift
+++ b/AppliveryBehaviorTests/ServicesTests/LoginServiceTests.swift
@@ -173,7 +173,8 @@ struct LoginServiceTests {
         var result: UpdateResult?
         loginService.requestAuthorization { r in result = r }
         waitUntil { result != nil }
-        #expect(result == .failure(error: .authRequired))
+        #expect(result?.type == .error)
+        #expect(result?.error == .authRequired)
     }
 
     @Test
@@ -210,11 +211,12 @@ struct LoginServiceTests {
             app: app,
             keychain: keychain
         )
-        downloadService.stubbedURL = nil
+        app.stubDeviceAvailableSpace = 1000
         var result: UpdateResult?
         loginService.download { r in result = r }
         waitUntil { result != nil }
-        #expect(result == .failure(error: .noDiskSpaceAvailable))
+        #expect(result?.type == .error)
+        #expect(result?.error == .noDiskSpaceAvailable)
     }
 
     @Test
@@ -241,6 +243,8 @@ struct LoginServiceTests {
             version: "0.9.0",
             buildNumber: "100"
         )
+        app.stubDeviceAvailableSpace = 6000000000
+        app.stubOpenUrlResult = true
         configService.currentConfigResponse = forceUpdateConfig
         let loginService = LoginService(
             loginRepository: loginRepository,
@@ -251,11 +255,11 @@ struct LoginServiceTests {
             app: app,
             keychain: keychain
         )
+
         downloadService.stubbedURL = "https://applivery.com/app.ipa"
         var result: UpdateResult?
         loginService.download { r in result = r }
         waitUntil { result != nil && downloadService.downloadURLCalled }
-
         #expect(result?.type == .success)
         #expect(downloadService.downloadURLCalled)
     }

--- a/AppliveryBehaviorTests/ServicesTests/LoginServiceTests.swift
+++ b/AppliveryBehaviorTests/ServicesTests/LoginServiceTests.swift
@@ -20,17 +20,7 @@ struct LoginServiceTests {
         let app = AppMock()
         let keychain = MockKeychainManager()
         let forceUpdateConfig = UpdateConfigResponse(
-            config: SDKData(
-                minVersion: "1.0.0",
-                forceUpdate: true,
-                lastBuildId: "some-build-id",
-                mustUpdateMsg: nil,
-                ota: false,
-                lastBuildVersion: nil,
-                updateMsg: nil,
-                forceAuth: false,
-                lastBuildSize: 5000000000
-            ),
+            config: SDKData.mock,
             version: "0.9.0",
             buildNumber: "100"
         )
@@ -60,17 +50,7 @@ struct LoginServiceTests {
         let app = AppMock()
         let keychain = MockKeychainManager()
         let forceUpdateConfig = UpdateConfigResponse(
-            config: SDKData(
-                minVersion: "1.0.0",
-                forceUpdate: true,
-                lastBuildId: "some-build-id",
-                mustUpdateMsg: nil,
-                ota: false,
-                lastBuildVersion: nil,
-                updateMsg: nil,
-                forceAuth: false,
-                lastBuildSize: 5000000000
-            ),
+            config: SDKData.mock,
             version: "0.9.0",
             buildNumber: "100"
         )
@@ -100,17 +80,7 @@ struct LoginServiceTests {
         let app = AppMock()
         let keychain = MockKeychainManager()
         let forceUpdateConfig = UpdateConfigResponse(
-            config: SDKData(
-                minVersion: "1.0.0",
-                forceUpdate: true,
-                lastBuildId: "some-build-id",
-                mustUpdateMsg: nil,
-                ota: false,
-                lastBuildVersion: nil,
-                updateMsg: nil,
-                forceAuth: false,
-                lastBuildSize: 5000000000
-            ),
+            config: SDKData.mock,
             version: "0.9.0",
             buildNumber: "100"
         )
@@ -145,17 +115,7 @@ struct LoginServiceTests {
         let app = AppMock()
         let keychain = MockKeychainManager()
         let forceUpdateConfig = UpdateConfigResponse(
-            config: SDKData(
-                minVersion: "1.0.0",
-                forceUpdate: true,
-                lastBuildId: "some-build-id",
-                mustUpdateMsg: nil,
-                ota: false,
-                lastBuildVersion: nil,
-                updateMsg: nil,
-                forceAuth: false,
-                lastBuildSize: 5000000000
-            ),
+            config: SDKData.mock,
             version: "0.9.0",
             buildNumber: "100"
         )
@@ -187,17 +147,7 @@ struct LoginServiceTests {
         let app = AppMock()
         let keychain = MockKeychainManager()
         let forceUpdateConfig = UpdateConfigResponse(
-            config: SDKData(
-                minVersion: "1.0.0",
-                forceUpdate: true,
-                lastBuildId: "some-build-id",
-                mustUpdateMsg: nil,
-                ota: false,
-                lastBuildVersion: nil,
-                updateMsg: nil,
-                forceAuth: false,
-                lastBuildSize: 5000000000
-            ),
+            config: SDKData.mock,
             version: "0.9.0",
             buildNumber: "100"
         )
@@ -229,17 +179,7 @@ struct LoginServiceTests {
         let app = AppMock()
         let keychain = MockKeychainManager()
         let forceUpdateConfig = UpdateConfigResponse(
-            config: SDKData(
-                minVersion: "1.0.0",
-                forceUpdate: true,
-                lastBuildId: "some-build-id",
-                mustUpdateMsg: nil,
-                ota: false,
-                lastBuildVersion: nil,
-                updateMsg: nil,
-                forceAuth: false,
-                lastBuildSize: 5000000000
-            ),
+            config: SDKData.mock,
             version: "0.9.0",
             buildNumber: "100"
         )

--- a/AppliveryBehaviorTests/ServicesTests/UpdateServiceTests.swift
+++ b/AppliveryBehaviorTests/ServicesTests/UpdateServiceTests.swift
@@ -150,7 +150,7 @@ struct UpdateServiceTests {
                 lastBuildId: nil,
                 mustUpdateMsg: nil,
                 ota: true,
-                lastBuildVersion: "2.0.0",
+                lastBuildVersion: "101",
                 updateMsg: nil,
                 forceAuth: false
             ),
@@ -158,8 +158,6 @@ struct UpdateServiceTests {
             buildNumber: "100"
         )
         configService.currentConfigResponse = otaUpdateConfig
-        appMock.stubVersion = "1.0.0" // ensure app version is older than lastBuildVersion
-        // Ensure no postpone is set so shouldShowPopup() returns true
         userDefaults?.removeObject(forKey: AppliveryUserDefaultsKeys.appliveryLastUpdatePopupShown)
         userDefaults?.removeObject(forKey: AppliveryUserDefaultsKeys.appliveryPostponeInterval)
         // WHEN

--- a/AppliveryBehaviorTests/ServicesTests/UpdateServiceTests.swift
+++ b/AppliveryBehaviorTests/ServicesTests/UpdateServiceTests.swift
@@ -128,7 +128,8 @@ struct UpdateServiceTests {
                 ota: false,
                 lastBuildVersion: nil,
                 updateMsg: nil,
-                forceAuth: false
+                forceAuth: false,
+                lastBuildSize: nil
             ),
             version: "0.9.0",
             buildNumber: "100"
@@ -152,7 +153,8 @@ struct UpdateServiceTests {
                 ota: true,
                 lastBuildVersion: "2.0.0",
                 updateMsg: nil,
-                forceAuth: false
+                forceAuth: false,
+                lastBuildSize: nil
             ),
             version: "1.0.0",
             buildNumber: "100"

--- a/AppliveryBehaviorTests/ServicesTests/UpdateServiceTests.swift
+++ b/AppliveryBehaviorTests/ServicesTests/UpdateServiceTests.swift
@@ -9,7 +9,7 @@ import Testing
 @testable import Applivery
 
 // Helper to wait for a condition or timeout
-func waitUntil(timeout: TimeInterval = 10.0, interval: TimeInterval = 0.01, _ condition: @escaping () -> Bool) {
+func waitUntil(timeout: TimeInterval = 50.0, interval: TimeInterval = 0.01, _ condition: @escaping () -> Bool) {
     let start = Date()
     while !condition() && Date().timeIntervalSince(start) < timeout {
         RunLoop.main.run(until: Date().addingTimeInterval(interval))

--- a/AppliveryBehaviorTests/ServicesTests/UpdateServiceTests.swift
+++ b/AppliveryBehaviorTests/ServicesTests/UpdateServiceTests.swift
@@ -206,7 +206,8 @@ struct UpdateServiceTests {
                 ota: true,
                 lastBuildVersion: "101",
                 updateMsg: nil,
-                forceAuth: false
+                forceAuth: false,
+                lastBuildSize: nil
             ),
             version: "0.9.0",  // <-- This is essentially irrelevant
             buildNumber: "100" // <-- This is the app buildNumber
@@ -245,7 +246,8 @@ struct UpdateServiceTests {
                 ota: true,
                 lastBuildVersion: "101",
                 updateMsg: nil,
-                forceAuth: false
+                forceAuth: false,
+                lastBuildSize: nil
             ),
             version: "0.9.0",  // <-- This is essentially irrelevant
             buildNumber: "102" // <-- This is the app buildNumber

--- a/AppliveryBehaviorTests/ServicesTests/UpdateServiceTests.swift
+++ b/AppliveryBehaviorTests/ServicesTests/UpdateServiceTests.swift
@@ -9,7 +9,7 @@ import Testing
 @testable import Applivery
 
 // Helper to wait for a condition or timeout
-func waitUntil(timeout: TimeInterval = 2.0, interval: TimeInterval = 0.01, _ condition: @escaping () -> Bool) {
+func waitUntil(timeout: TimeInterval = 10.0, interval: TimeInterval = 0.01, _ condition: @escaping () -> Bool) {
     let start = Date()
     while !condition() && Date().timeIntervalSince(start) < timeout {
         RunLoop.main.run(until: Date().addingTimeInterval(interval))

--- a/AppliveryBehaviorTests/ServicesTests/UpdateServiceTests.swift
+++ b/AppliveryBehaviorTests/ServicesTests/UpdateServiceTests.swift
@@ -101,8 +101,7 @@ struct UpdateServiceTests {
         #expect(eventDetector.spyEndListeningCalled == true)
     }
 
-    @Test
-    func checkUpdate() {
+    @Test func testCheckUpdateForced() async throws {
         // GIVEN
         let appMock = AppMock()
         let eventDetector = EventDetectorMock()
@@ -118,35 +117,88 @@ struct UpdateServiceTests {
             globalConfig: globalConfig,
             eventDetector: eventDetector
         )
-        // Force update config
         let forceUpdateConfig = UpdateConfigResponse(
             config: SDKData(
-                minVersion: "1.0.0",
-                forceUpdate: true,
+                minVersion: "101",   // <-- This is the buildnumber the app must have
+                forceUpdate: true,   // <-- when forceUpdate is set to true
                 lastBuildId: nil,
                 mustUpdateMsg: nil,
                 ota: false,
-                lastBuildVersion: nil,
+                lastBuildVersion: "101",
                 updateMsg: nil,
                 forceAuth: false
             ),
-            version: "0.9.0",
-            buildNumber: "100"
+            version: "0.9.0",  // <-- This is essentially irrelevant
+            buildNumber: "100" // <-- This is the app buildNumber
         )
         configService.currentConfigResponse = forceUpdateConfig
-        appMock.stubVersion = "0.9.0" // ensure app version is older than minVersion
         // WHEN
         updateService.checkUpdate(for: forceUpdateConfig, forceUpdate: true)
         // Wait until the async force update is called or timeout
         waitUntil { appMock.spyForceUpdateCalled }
         // THEN
         #expect(appMock.spyForceUpdateCalled == true)
+    }
 
-        // OTA update config
-        let otaUpdateConfig = UpdateConfigResponse(
+    @Test func testCheckUpdateForcedNotNeeded() async throws {
+        // GIVEN
+        let appMock = AppMock()
+        let eventDetector = EventDetectorMock()
+        let configService = ConfigServiceMock()
+        let downloadService = DownloadService()
+        let loginService = LoginService()
+        let globalConfig = GlobalConfig()
+        let updateService = UpdateService(
+            configService: configService,
+            downloadService: downloadService,
+            app: appMock,
+            loginService: loginService,
+            globalConfig: globalConfig,
+            eventDetector: eventDetector
+        )
+        let forceUpdateConfig = UpdateConfigResponse(
+            config: SDKData(
+                minVersion: "101",   // <-- This is the buildnumber the app must have
+                forceUpdate: true,   // <-- when forceUpdate is set to true
+                lastBuildId: nil,
+                mustUpdateMsg: nil,
+                ota: false,
+                lastBuildVersion: "101",
+                updateMsg: nil,
+                forceAuth: false
+            ),
+            version: "0.9.0",  // <-- This is essentially irrelevant
+            buildNumber: "101" // <-- This is the app buildNumber
+        )
+        configService.currentConfigResponse = forceUpdateConfig
+        // WHEN
+        updateService.checkUpdate(for: forceUpdateConfig, forceUpdate: true)
+        // Wait until the async force update is called or timeout
+        waitUntil { appMock.spyForceUpdateCalled }
+        // THEN
+        #expect(appMock.spyForceUpdateCalled == false)
+    }
+
+    @Test func testCheckOtaUpdate() async throws {
+        // GIVEN
+        let appMock = AppMock()
+        let eventDetector = EventDetectorMock()
+        let configService = ConfigServiceMock()
+        let downloadService = DownloadService()
+        let loginService = LoginService()
+        let globalConfig = GlobalConfig()
+        let updateService = UpdateService(
+            configService: configService,
+            downloadService: downloadService,
+            app: appMock,
+            loginService: loginService,
+            globalConfig: globalConfig,
+            eventDetector: eventDetector
+        )
+        let forceUpdateConfig = UpdateConfigResponse(
             config: SDKData(
                 minVersion: nil,
-                forceUpdate: false,
+                forceUpdate: true,
                 lastBuildId: nil,
                 mustUpdateMsg: nil,
                 ota: true,
@@ -154,18 +206,55 @@ struct UpdateServiceTests {
                 updateMsg: nil,
                 forceAuth: false
             ),
-            version: "1.0.0",
-            buildNumber: "100"
+            version: "0.9.0",  // <-- This is essentially irrelevant
+            buildNumber: "100" // <-- This is the app buildNumber
         )
-        configService.currentConfigResponse = otaUpdateConfig
-        userDefaults?.removeObject(forKey: AppliveryUserDefaultsKeys.appliveryLastUpdatePopupShown)
-        userDefaults?.removeObject(forKey: AppliveryUserDefaultsKeys.appliveryPostponeInterval)
+        configService.currentConfigResponse = forceUpdateConfig
         // WHEN
-        updateService.checkUpdate(for: otaUpdateConfig, forceUpdate: false)
-        // Wait until the async alert is called or timeout
-        waitUntil { appMock.spyOtaAlert.called }
+        updateService.checkUpdate(for: forceUpdateConfig, forceUpdate: false)
+        // Wait until the async force update is called or timeout
+        waitUntil { appMock.spyForceUpdateCalled }
         // THEN
         #expect(appMock.spyOtaAlert.called == true)
+    }
+
+    @Test func testCheckOtaUpdateNotNeeded() async throws {
+        // GIVEN
+        let appMock = AppMock()
+        let eventDetector = EventDetectorMock()
+        let configService = ConfigServiceMock()
+        let downloadService = DownloadService()
+        let loginService = LoginService()
+        let globalConfig = GlobalConfig()
+        let updateService = UpdateService(
+            configService: configService,
+            downloadService: downloadService,
+            app: appMock,
+            loginService: loginService,
+            globalConfig: globalConfig,
+            eventDetector: eventDetector
+        )
+        let forceUpdateConfig = UpdateConfigResponse(
+            config: SDKData(
+                minVersion: nil,
+                forceUpdate: true,
+                lastBuildId: nil,
+                mustUpdateMsg: nil,
+                ota: true,
+                lastBuildVersion: "101",
+                updateMsg: nil,
+                forceAuth: false
+            ),
+            version: "0.9.0",  // <-- This is essentially irrelevant
+            buildNumber: "102" // <-- This is the app buildNumber
+        )
+        configService.currentConfigResponse = forceUpdateConfig
+        // WHEN
+        updateService.checkUpdate(for: forceUpdateConfig, forceUpdate: false)
+        // Wait until the async force update is called or timeout
+        waitUntil { appMock.spyForceUpdateCalled }
+        // THEN
+        #expect(appMock.spyOtaAlert.called == false)
     }
 }
 

--- a/AppliveryBehaviorTests/ServicesTests/UpdateServiceTests.swift
+++ b/AppliveryBehaviorTests/ServicesTests/UpdateServiceTests.swift
@@ -9,7 +9,7 @@ import Testing
 @testable import Applivery
 
 // Helper to wait for a condition or timeout
-func waitUntil(timeout: TimeInterval = 50.0, interval: TimeInterval = 0.01, _ condition: @escaping () -> Bool) {
+func waitUntil(timeout: TimeInterval = 20.0, interval: TimeInterval = 0.01, _ condition: @escaping () -> Bool) {
     let start = Date()
     while !condition() && Date().timeIntervalSince(start) < timeout {
         RunLoop.main.run(until: Date().addingTimeInterval(interval))
@@ -197,7 +197,7 @@ struct UpdateServiceTests {
             globalConfig: globalConfig,
             eventDetector: eventDetector
         )
-        let forceUpdateConfig = UpdateConfigResponse(
+        let otaConfig = UpdateConfigResponse(
             config: SDKData(
                 minVersion: nil,
                 forceUpdate: true,
@@ -212,11 +212,11 @@ struct UpdateServiceTests {
             version: "0.9.0",  // <-- This is essentially irrelevant
             buildNumber: "100" // <-- This is the app buildNumber
         )
-        configService.currentConfigResponse = forceUpdateConfig
+        configService.currentConfigResponse = otaConfig
         // WHEN
-        updateService.checkUpdate(for: forceUpdateConfig, forceUpdate: false)
+        updateService.checkUpdate(for: otaConfig, forceUpdate: false)
         // Wait until the async force update is called or timeout
-        waitUntil { appMock.spyForceUpdateCalled }
+        waitUntil { appMock.spyOtaAlert.called }
         // THEN
         #expect(appMock.spyOtaAlert.called == true)
     }
@@ -237,7 +237,7 @@ struct UpdateServiceTests {
             globalConfig: globalConfig,
             eventDetector: eventDetector
         )
-        let forceUpdateConfig = UpdateConfigResponse(
+        let otaConfig = UpdateConfigResponse(
             config: SDKData(
                 minVersion: nil,
                 forceUpdate: true,
@@ -252,11 +252,9 @@ struct UpdateServiceTests {
             version: "0.9.0",  // <-- This is essentially irrelevant
             buildNumber: "102" // <-- This is the app buildNumber
         )
-        configService.currentConfigResponse = forceUpdateConfig
+        configService.currentConfigResponse = otaConfig
         // WHEN
-        updateService.checkUpdate(for: forceUpdateConfig, forceUpdate: false)
-        // Wait until the async force update is called or timeout
-        waitUntil { appMock.spyForceUpdateCalled }
+        updateService.checkUpdate(for: otaConfig, forceUpdate: false)
         // THEN
         #expect(appMock.spyOtaAlert.called == false)
     }

--- a/AppliverySDK/Applivery/AppliverySDK.swift
+++ b/AppliverySDK/Applivery/AppliverySDK.swift
@@ -118,7 +118,7 @@ public typealias AppliveryLogHandler = @convention(block) (
  */
 public class AppliverySDK: NSObject, AppliveryService {
     // MARK: Static Properties
-    internal static let sdkVersion = "4.5.1"
+    internal static let sdkVersion = "4.5.2"
 
     // MARK: Type Properties
     /// Singleton instance

--- a/AppliverySDK/Applivery/AppliverySDK.swift
+++ b/AppliverySDK/Applivery/AppliverySDK.swift
@@ -41,7 +41,7 @@ import UIKit
 ///
 /// This enumeration is compatible with Objective-C and provides a list of detailed errors that
 /// describe potential failures during the update process.
-@objc public enum UpdateError: Int {
+@objc public enum UpdateError: Int, Error {
 
     /// No error; used to represent a state without errors.
     case noError = 0
@@ -60,6 +60,12 @@ import UIKit
 
     /// Indicates that the app is up to date.
     case isUpToDate = 1005
+
+    /// Indicates there was an error retrieving free space in the device
+    case unableToDetermineFreeSpace = 1006
+
+    /// Indicates there is not enough free space in the device
+    case noDiskSpaceAvailable = 1007
 
 }
 

--- a/AppliverySDK/Data/Persisters/ConfigPersister.swift
+++ b/AppliverySDK/Data/Persisters/ConfigPersister.swift
@@ -16,6 +16,7 @@ let kOtaUpdateKey			= "APPLIVERY_OTA_UPDATE_KEY"
 let kLastBuildVersion		= "APPLIVERY_LAST_BUILD_VERSION"
 let kOtaUpdateMessageKey	= "APPLIVERY_OTA_UPDATE_MESSAGE"
 let kForceAuth				= "APPLIVERY_FORCE_AUTH"
+let kLastBuildSize          = "APPLIVERY_LASTBUILDSIZE"
 
 protocol UserDefaultsProtocol {
 	func value(forKey key: String) -> Any?
@@ -43,14 +44,12 @@ class ConfigPersister: NSObject {
 	///  Get the current config stored on disk
 	///  - returns: config object with the data stored. Could be nil if no previus data was saved
     func getConfig() -> SDKData? {
-        
 		guard
 			let forceUpdate			= self.userDefaults.value(forKey: kForceUpdateKey)		as? Bool,
 			let lastBuildId			= self.userDefaults.value(forKey: kLastBuildId)			as? String,
 			let otaUpdate			= self.userDefaults.value(forKey: kOtaUpdateKey)		as? Bool,
 			let lastBuildVersion	= self.userDefaults.value(forKey: kLastBuildVersion)	as? String
 			else { return nil }
-
         let sdkData = SDKData(
             minVersion: self.userDefaults.value(forKey: kMinVersionKey) as? String ?? "",
             forceUpdate: forceUpdate,
@@ -59,7 +58,8 @@ class ConfigPersister: NSObject {
             ota: otaUpdate,
             lastBuildVersion: lastBuildVersion,
             updateMsg: self.userDefaults.value(forKey: kForceUpdateMessageKey) as? String ?? "",
-            forceAuth: self.userDefaults.value(forKey: kForceAuth) as? Bool ?? false
+            forceAuth: self.userDefaults.value(forKey: kForceAuth) as? Bool ?? false,
+            lastBuildSize: self.userDefaults.value(forKey: kLastBuildSize) as? Int
         )
 
 		return sdkData
@@ -74,6 +74,7 @@ class ConfigPersister: NSObject {
         self.userDefaults.setValue(config.lastBuildVersion as AnyObject?, forKey: kLastBuildVersion)
         self.userDefaults.setValue(config.updateMsg as AnyObject?, forKey: kOtaUpdateMessageKey)
 		self.userDefaults.set(config.forceAuth, forKey: kForceAuth)
+        self.userDefaults.setValue(config.lastBuildSize, forKey: kLastBuildSize)
 
 		if self.userDefaults.synchronize() {
 			logInfo("Applivery configuration was updated")

--- a/AppliverySDK/Data/Persisters/SessionPersister.swift
+++ b/AppliverySDK/Data/Persisters/SessionPersister.swift
@@ -27,12 +27,7 @@ protocol SessionPersisterProtocol {
 
 struct SessionPersister: SessionPersisterProtocol {
 	let userDefaults: UserDefaultsProtocol
-	
-//	func save(accessToken: AccessToken?) {
-//		self.userDefaults.set(accessToken, forKey: kAccessTokenKey)
-//		_ = self.userDefaults.synchronize()
-//	}
-	
+
 	func loadAccessToken() -> AccessToken? {
 		let accessToken: AccessToken? = self.userDefaults.token(forKey: kAccessTokenKey)
 		return accessToken

--- a/AppliverySDK/Data/Persisters/SessionPersister.swift
+++ b/AppliverySDK/Data/Persisters/SessionPersister.swift
@@ -18,8 +18,14 @@ enum KeychainError: Error {
     case itemNotFound
 }
 
+protocol SessionPersisterProtocol {
+    func loadAccessToken() -> AccessToken?
+    func saveUserName(userName: String)
+    func loadUserName() -> String
+    func removeUser()
+}
 
-struct SessionPersister {
+struct SessionPersister: SessionPersisterProtocol {
 	let userDefaults: UserDefaultsProtocol
 	
 //	func save(accessToken: AccessToken?) {

--- a/AppliverySDK/Model/Config.swift
+++ b/AppliverySDK/Model/Config.swift
@@ -35,4 +35,5 @@ struct SDKData: Codable {
     let lastBuildVersion: String?
     let updateMsg: String?
     let forceAuth: Bool
+    let lastBuildSize: Int? // Size in bytes
 }

--- a/AppliverySDK/Services/LoginService.swift
+++ b/AppliverySDK/Services/LoginService.swift
@@ -127,12 +127,16 @@ final class LoginService: LoginServiceProtocol {
             let freeSpace = try app.deviceAvailableSpace()
             if freeSpace < (lastConfig.config?.lastBuildSize ?? 0) {
                 onResult?(.failure(error: .noDiskSpaceAvailable))
-                app.showErrorAlert("Insufficient storage")
+                DispatchQueue.main.async {
+                    self.app.showErrorAlert("Insufficient storage")
+                }
                 return
             }
         } catch {
             onResult?(.failure(error: .unableToDetermineFreeSpace))
-            app.showErrorAlert("Could not read if there is enough storage in the device")
+            DispatchQueue.main.async {
+                self.app.showErrorAlert("Could not read if there is enough storage in the device")
+            }
             return
         }
         Task {

--- a/AppliverySDK/Services/LoginService.swift
+++ b/AppliverySDK/Services/LoginService.swift
@@ -25,7 +25,7 @@ final class LoginService: LoginServiceProtocol {
     let configService: ConfigServiceProtocol
     let downloadService: DownloadServiceProtocol
     let globalConfig: GlobalConfig
-    let sessionPersister: SessionPersister
+    let sessionPersister: SessionPersisterProtocol
     let safariManager: AppliverySafariManagerProtocol
     let app: AppProtocol
     let keychain: KeychainAccessible
@@ -40,7 +40,7 @@ final class LoginService: LoginServiceProtocol {
         configService: ConfigServiceProtocol = ConfigService(),
         downloadService: DownloadServiceProtocol = DownloadService(),
         globalConfig: GlobalConfig = GlobalConfig.shared,
-        sessionPersister: SessionPersister = SessionPersister(userDefaults: UserDefaults.standard),
+        sessionPersister: SessionPersisterProtocol = SessionPersister(userDefaults: UserDefaults.standard),
         webViewManager: AppliverySafariManagerProtocol = AppliverySafariManager.shared,
         app: AppProtocol = App(),
         keychain: KeychainAccessible = Keychain()
@@ -123,7 +123,18 @@ final class LoginService: LoginServiceProtocol {
             onResult?(.failure(error: .noConfigFound))
             return
         }
-
+        do {
+            let freeSpace = try deviceAvailableSpace()
+            if freeSpace < (lastConfig.config?.lastBuildSize ?? 0) {
+                onResult?(.failure(error: .noDiskSpaceAvailable))
+                app.showErrorAlert("Insufficient storage")
+                return
+            }
+        } catch {
+            onResult?(.failure(error: .unableToDetermineFreeSpace))
+            app.showErrorAlert("Could not read if there is enough storage in the device")
+            return
+        }
         Task {
             if let url = await downloadService.downloadURL(lastBuildId) {
                 await MainActor.run {
@@ -146,7 +157,6 @@ final class LoginService: LoginServiceProtocol {
 }
 
 private extension LoginService {
-
     @MainActor
     func store(accessToken: AccessToken, userName: String) {
         logInfo("Fetched new access token: \(accessToken.token ?? "NO TOKEN")")
@@ -159,6 +169,17 @@ private extension LoginService {
                 logError(error as NSError)
                 app.showErrorAlert("Error storing token")
             }
+        }
+    }
+
+    func deviceAvailableSpace() throws -> Int64 {
+        let homeURL = URL(fileURLWithPath: NSHomeDirectory())
+        let resourceKeys: Set<URLResourceKey> = [.volumeAvailableCapacityForImportantUsageKey]
+        let resourceValues = try homeURL.resourceValues(forKeys: resourceKeys)
+        if let availableCapacity = resourceValues.volumeAvailableCapacityForImportantUsage {
+            return availableCapacity
+        } else {
+            throw UpdateError.unableToDetermineFreeSpace
         }
     }
 }

--- a/AppliverySDK/Services/LoginService.swift
+++ b/AppliverySDK/Services/LoginService.swift
@@ -124,7 +124,7 @@ final class LoginService: LoginServiceProtocol {
             return
         }
         do {
-            let freeSpace = try deviceAvailableSpace()
+            let freeSpace = try app.deviceAvailableSpace()
             if freeSpace < (lastConfig.config?.lastBuildSize ?? 0) {
                 onResult?(.failure(error: .noDiskSpaceAvailable))
                 app.showErrorAlert("Insufficient storage")
@@ -169,17 +169,6 @@ private extension LoginService {
                 logError(error as NSError)
                 app.showErrorAlert("Error storing token")
             }
-        }
-    }
-
-    func deviceAvailableSpace() throws -> Int64 {
-        let homeURL = URL(fileURLWithPath: NSHomeDirectory())
-        let resourceKeys: Set<URLResourceKey> = [.volumeAvailableCapacityForImportantUsageKey]
-        let resourceValues = try homeURL.resourceValues(forKeys: resourceKeys)
-        if let availableCapacity = resourceValues.volumeAvailableCapacityForImportantUsage {
-            return availableCapacity
-        } else {
-            throw UpdateError.unableToDetermineFreeSpace
         }
     }
 }

--- a/AppliverySDK/Services/LoginService.swift
+++ b/AppliverySDK/Services/LoginService.swift
@@ -120,14 +120,12 @@ final class LoginService: LoginServiceProtocol {
     func download(onResult: ((UpdateResult) -> Void)? = nil) {
         let lastConfig = configService.getCurrentConfig()
         guard let lastBuildId = lastConfig.config?.lastBuildId else {
-            logInfo(" 🗑️ Delete me! No config was found")
             onResult?(.failure(error: .noConfigFound))
             return
         }
         do {
             let freeSpace = try app.deviceAvailableSpace()
             if freeSpace < (lastConfig.config?.lastBuildSize ?? 0) {
-                logInfo("🗑️ Delete me! Insufficient storage")
                 onResult?(.failure(error: .noDiskSpaceAvailable))
                 DispatchQueue.main.async {
                     self.app.showErrorAlert("Insufficient storage")
@@ -135,7 +133,6 @@ final class LoginService: LoginServiceProtocol {
                 return
             }
         } catch {
-            logInfo(" 🗑️ Delete me! Unable to determine free space")
             onResult?(.failure(error: .unableToDetermineFreeSpace))
             DispatchQueue.main.async {
                 self.app.showErrorAlert("Could not read if there is enough storage in the device")
@@ -146,18 +143,15 @@ final class LoginService: LoginServiceProtocol {
             if let url = await downloadService.downloadURL(lastBuildId) {
                 await MainActor.run {
                     if app.openUrl(url) {
-                        logInfo(" 🗑️ Delete me! Success!")
                         onResult?(.success())
                     }
                     else {
-                        logInfo(" 🗑️ Delete me! Error download URL!")
                         let error = NSError.appliveryError(literal(.errorDownloadURL))
                         logError(error)
                         onResult?(.failure(error: .downloadManifestError))
                     }
                 }
             } else {
-                logInfo(" 🗑️ Delete me! URL not found!")
                 let error = NSError.appliveryError(literal(.errorDownloadURL))
                 logError(error)
                 onResult?(.failure(error: .downloadUrlNotFound))

--- a/AppliverySDK/Services/LoginService.swift
+++ b/AppliverySDK/Services/LoginService.swift
@@ -120,12 +120,14 @@ final class LoginService: LoginServiceProtocol {
     func download(onResult: ((UpdateResult) -> Void)? = nil) {
         let lastConfig = configService.getCurrentConfig()
         guard let lastBuildId = lastConfig.config?.lastBuildId else {
+            logInfo(" 🗑️ Delete me! No config was found")
             onResult?(.failure(error: .noConfigFound))
             return
         }
         do {
             let freeSpace = try app.deviceAvailableSpace()
             if freeSpace < (lastConfig.config?.lastBuildSize ?? 0) {
+                logInfo("🗑️ Delete me! Insufficient storage")
                 onResult?(.failure(error: .noDiskSpaceAvailable))
                 DispatchQueue.main.async {
                     self.app.showErrorAlert("Insufficient storage")
@@ -133,6 +135,7 @@ final class LoginService: LoginServiceProtocol {
                 return
             }
         } catch {
+            logInfo(" 🗑️ Delete me! Unable to determine free space")
             onResult?(.failure(error: .unableToDetermineFreeSpace))
             DispatchQueue.main.async {
                 self.app.showErrorAlert("Could not read if there is enough storage in the device")
@@ -143,15 +146,18 @@ final class LoginService: LoginServiceProtocol {
             if let url = await downloadService.downloadURL(lastBuildId) {
                 await MainActor.run {
                     if app.openUrl(url) {
+                        logInfo(" 🗑️ Delete me! Success!")
                         onResult?(.success())
                     }
                     else {
+                        logInfo(" 🗑️ Delete me! Error download URL!")
                         let error = NSError.appliveryError(literal(.errorDownloadURL))
                         logError(error)
                         onResult?(.failure(error: .downloadManifestError))
                     }
                 }
             } else {
+                logInfo(" 🗑️ Delete me! URL not found!")
                 let error = NSError.appliveryError(literal(.errorDownloadURL))
                 logError(error)
                 onResult?(.failure(error: .downloadUrlNotFound))

--- a/AppliverySDK/Services/UpdateService.swift
+++ b/AppliverySDK/Services/UpdateService.swift
@@ -147,7 +147,7 @@ final class UpdateService: UpdateServiceProtocol {
             forceUpdate
             else { return false }
 
-        logInfo("[checkForceUpdate] - Checking if build version: \(version) is older than minBuildVersion: \(minVersion)")
+        logInfo("[checkForceUpdate] - Checking if app version: \(version) is older than min version: \(minVersion)")
         if self.isOlder(version, minVersion: minVersion) {
             logInfo("[checkForceUpdate] - Application must be updated!!")
             return true
@@ -166,7 +166,7 @@ final class UpdateService: UpdateServiceProtocol {
             return false
         }
 
-        logInfo("[checkOtaUpdate] - Checking if app version: \(version) is older than last build version: \(lastVersion)")
+        logInfo("[checkOtaUpdate] - Checking if build number: \(version) is older than last build version: \(lastVersion)")
         if self.isOlder(version, minVersion: lastVersion) {
             logInfo("[checkOtaUpdate] - New OTA update available!")
             return true
@@ -197,6 +197,8 @@ final class UpdateService: UpdateServiceProtocol {
 
     func checkUpdate(for updateConfig: UpdateConfigResponse, forceUpdate: Bool) {
         let appVersion = app.getVersion()
+        let currentConfig = configService.getCurrentConfig()
+        let appBuildNumber = currentConfig.buildNumber
         // use existing helpers to determine if a force or ota update is needed
         if forceUpdate && checkForceUpdate(updateConfig.config, version: appVersion) {
             logInfo("Performing force update...")
@@ -204,7 +206,7 @@ final class UpdateService: UpdateServiceProtocol {
             return
         }
 
-        if checkOtaUpdate(updateConfig.config, version: appVersion) {
+        if checkOtaUpdate(updateConfig.config, version: appBuildNumber) {
             if shouldShowPopup() {
                 logInfo("Performing OTA update...")
                 otaUpdate()

--- a/AppliverySDK/Services/UpdateService.swift
+++ b/AppliverySDK/Services/UpdateService.swift
@@ -15,7 +15,7 @@ protocol UpdateServiceProtocol {
     func downloadLastBuild(onResult: ((UpdateResult) -> Void)?)
     func isUpToDate() async throws -> Bool
     func checkForceUpdate(_ config: SDKData?, version: String) -> Bool
-    func checkOtaUpdate(_ config: SDKData?, version: String) -> Bool
+    func checkOtaUpdate(_ config: SDKData?, buildNumber: String) -> Bool
     func forceUpdateMessage() -> String
     func setCheckForUpdatesBackground(_ enabled: Bool)
     func checkUpdate(for updateConfig: UpdateConfigResponse, forceUpdate: Bool)
@@ -156,7 +156,7 @@ final class UpdateService: UpdateServiceProtocol {
         return false
     }
 
-    func checkOtaUpdate(_ config: SDKData?, version: String) -> Bool {
+    func checkOtaUpdate(_ config: SDKData?, buildNumber: String) -> Bool {
         guard
             let lastVersion = config?.lastBuildVersion,
             let otaUpdate = config?.ota,
@@ -166,8 +166,8 @@ final class UpdateService: UpdateServiceProtocol {
             return false
         }
 
-        logInfo("[checkOtaUpdate] - Checking if build number: \(version) is older than last build version: \(lastVersion)")
-        if self.isOlder(version, minVersion: lastVersion) {
+        logInfo("[checkOtaUpdate] - Checking if build number: \(buildNumber) is older than last build version: \(lastVersion)")
+        if self.isOlder(buildNumber, minVersion: lastVersion) {
             logInfo("[checkOtaUpdate] - New OTA update available!")
             return true
         }
@@ -206,7 +206,7 @@ final class UpdateService: UpdateServiceProtocol {
             return
         }
 
-        if checkOtaUpdate(updateConfig.config, version: appBuildNumber) {
+        if checkOtaUpdate(updateConfig.config, buildNumber: appBuildNumber) {
             if shouldShowPopup() {
                 logInfo("Performing OTA update...")
                 otaUpdate()
@@ -290,7 +290,7 @@ private extension UpdateService {
     @objc func handleAppWillEnterForeground() {
         if globalConfig.isCheckForUpdatesBackgroundEnabled {
             let config = configService.getCurrentConfig()
-            if checkOtaUpdate(config.config, version: config.buildNumber) {
+            if checkOtaUpdate(config.config, buildNumber: config.buildNumber) {
                 otaUpdate()
             }
             logInfo("App returned from background, checking for updates...")

--- a/AppliverySDK/Services/UpdateService.swift
+++ b/AppliverySDK/Services/UpdateService.swift
@@ -110,7 +110,6 @@ final class UpdateService: UpdateServiceProtocol {
             logInfo("Force authorization is disabled - downloading last build")
             loginService.download(onResult: onResult)
         }
-
     }
 
     func isUpToDate() async -> Bool {

--- a/AppliverySDK/Services/UpdateService.swift
+++ b/AppliverySDK/Services/UpdateService.swift
@@ -14,8 +14,8 @@ protocol UpdateServiceProtocol {
     func otaUpdate()
     func downloadLastBuild(onResult: ((UpdateResult) -> Void)?)
     func isUpToDate() async throws -> Bool
-    func checkForceUpdate(_ config: SDKData?, version: String) -> Bool
-    func checkOtaUpdate(_ config: SDKData?, version: String, buildNumber: String) -> Bool
+    func checkForceUpdate(_ config: SDKData?, buildNumber: String) -> Bool
+    func checkOtaUpdate(_ config: SDKData?, buildNumber: String) -> Bool
     func forceUpdateMessage() -> String
     func setCheckForUpdatesBackground(_ enabled: Bool)
     func checkUpdate(for updateConfig: UpdateConfigResponse, forceUpdate: Bool)
@@ -119,12 +119,12 @@ final class UpdateService: UpdateServiceProtocol {
              let config = try await configService.fetchConfig()
              let forceUpdate = config.data.sdk.ios.forceUpdate
              if let minVersion = config.data.sdk.ios.minVersion, forceUpdate, !minVersion.isEmpty {
-                 let isOlder = isOlder(version: currentConfig.version, buildNumber: currentConfig.buildNumber, thanVersion: minVersion, thanBuildNumber: "0")
+                 let isOlder = isNewVersionOlder(currentVersion: currentConfig.buildNumber, newVersion: minVersion)
                  logInfo("[isUpToDate] - Force update is available, checking if \(currentConfig.version) is older than \(minVersion), Need update: \(!isOlder)")
                  return !isOlder
              }
              if let lastVersion = config.data.sdk.ios.lastBuildVersion, !lastVersion.isEmpty {
-                 let isOlder = isOlder(version: currentConfig.version, buildNumber: currentConfig.buildNumber, thanVersion: currentConfig.version, thanBuildNumber: lastVersion)
+                 let isOlder = isNewVersionOlder(currentVersion: currentConfig.buildNumber, newVersion: lastVersion)
                  logInfo("[isUpToDate] - Last Build version is available, Need update: \(isOlder)")
                  return !isOlder
              }
@@ -132,7 +132,7 @@ final class UpdateService: UpdateServiceProtocol {
          } catch {
              logInfo("[isUpToDate] - fetchConfig failed: \(error). Falling back to currentConfig minVersion check.")
              if let minVersion = currentConfig.config?.minVersion, !minVersion.isEmpty {
-                 let isOlder = isOlder(version: currentConfig.version, buildNumber: currentConfig.buildNumber, thanVersion: minVersion, thanBuildNumber: "0")
+                 let isOlder = isNewVersionOlder(currentVersion: currentConfig.version, newVersion: minVersion)
                  logInfo("[isUpToDate] - Fallback: checking if \(currentConfig.version) is older than \(minVersion), Need update: \(!isOlder)")
                  return !isOlder
              }
@@ -140,7 +140,7 @@ final class UpdateService: UpdateServiceProtocol {
          }
      }
 
-    func checkForceUpdate(_ config: SDKData?, version: String) -> Bool {
+    func checkForceUpdate(_ config: SDKData?, buildNumber: String) -> Bool {
         guard
             let minVersion = config?.minVersion,
             let forceUpdate = config?.forceUpdate,
@@ -148,8 +148,8 @@ final class UpdateService: UpdateServiceProtocol {
             else { return false }
 
         let currentBuildNumber = configService.getCurrentConfig().buildNumber
-        logInfo("[checkForceUpdate] - Checking if app version: \(version) (build: \(currentBuildNumber)) is older than min version: \(minVersion)")
-        if self.isOlder(version: version, buildNumber: currentBuildNumber, thanVersion: minVersion, thanBuildNumber: "0") {
+        logInfo("[checkForceUpdate] - Checking if buildNumber: \(currentBuildNumber) is older than min version: \(minVersion)")
+        if self.isNewVersionOlder(currentVersion: currentBuildNumber, newVersion: minVersion) {
             logInfo("[checkForceUpdate] - Application must be updated!!")
             return true
         }
@@ -157,7 +157,7 @@ final class UpdateService: UpdateServiceProtocol {
         return false
     }
 
-    func checkOtaUpdate(_ config: SDKData?, version: String, buildNumber: String) -> Bool {
+    func checkOtaUpdate(_ config: SDKData?, buildNumber: String) -> Bool {
         guard
             let lastVersion = config?.lastBuildVersion,
             let otaUpdate = config?.ota,
@@ -166,10 +166,9 @@ final class UpdateService: UpdateServiceProtocol {
             logInfo("[checkOtaUpdate] - ota update not needed")
             return false
         }
-
         // Keep semantic version neutral by using the same version on both sides; compare build numbers
-        logInfo("[checkOtaUpdate] - Checking if app (version: \(version), build: \(buildNumber)) is older than last build version: \(lastVersion)")
-        if self.isOlder(version: version, buildNumber: buildNumber, thanVersion: version, thanBuildNumber: lastVersion) {
+        logInfo("[checkOtaUpdate] - Checking if app (buildNumber: \(buildNumber)), is older than last build version: \(lastVersion)")
+        if self.isNewVersionOlder(currentVersion: buildNumber, newVersion: lastVersion) {
             logInfo("[checkOtaUpdate] - New OTA update available!")
             return true
         }
@@ -198,17 +197,16 @@ final class UpdateService: UpdateServiceProtocol {
     }
 
     func checkUpdate(for updateConfig: UpdateConfigResponse, forceUpdate: Bool) {
-        let appVersion = app.getVersion()
         let currentConfig = configService.getCurrentConfig()
         let appBuildNumber = currentConfig.buildNumber
         // use existing helpers to determine if a force or ota update is needed
-        if forceUpdate && checkForceUpdate(updateConfig.config, version: appVersion) {
+        if forceUpdate && checkForceUpdate(updateConfig.config, buildNumber: appBuildNumber) {
             logInfo("Performing force update...")
             self.forceUpdate()
             return
         }
 
-        if checkOtaUpdate(updateConfig.config, version: appVersion, buildNumber: appBuildNumber) {
+        if checkOtaUpdate(updateConfig.config, buildNumber: appBuildNumber) {
             if shouldShowPopup() {
                 logInfo("Performing OTA update...")
                 otaUpdate()
@@ -256,34 +254,11 @@ private extension UpdateService {
         }
     }
 
-    func isOlder(_ currentVersion: String, minVersion: String) -> Bool {
-        let (current, min) = self.equalLengthFillingWithZeros(left: currentVersion, right: minVersion)
+    func isNewVersionOlder(currentVersion: String, newVersion: String) -> Bool {
+        let (current, min) = self.equalLengthFillingWithZeros(left: currentVersion, right: newVersion)
         let result = current.compare(min, options: NSString.CompareOptions.numeric, range: nil, locale: nil)
 
         return result == ComparisonResult.orderedAscending
-    }
-
-    // New helper to compare semantic version + build number pairs.
-    // Returns true if (version, buildNumber) is older than (thanVersion, thanBuildNumber).
-    func isOlder(version: String, buildNumber: String, thanVersion: String, thanBuildNumber: String) -> Bool {
-        // Compare semantic versions first
-        let leftVersion = version.isEmpty ? "0" : version
-        let rightVersion = thanVersion.isEmpty ? "0" : thanVersion
-        let (leftFilled, rightFilled) = self.equalLengthFillingWithZeros(left: leftVersion, right: rightVersion)
-        let versionComparison = leftFilled.compare(rightFilled, options: .numeric, range: nil, locale: nil)
-
-        switch versionComparison {
-        case .orderedAscending:
-            return true // current version older than target version
-        case .orderedDescending:
-            return false // current version newer than target version
-        case .orderedSame:
-            // If versions are equal, compare build numbers numerically
-            let leftBuild = buildNumber.isEmpty ? "0" : buildNumber
-            let rightBuild = thanBuildNumber.isEmpty ? "0" : thanBuildNumber
-            let buildComparison = leftBuild.compare(rightBuild, options: .numeric, range: nil, locale: nil)
-            return buildComparison == .orderedAscending
-        }
     }
 
     func equalLengthFillingWithZeros(left: String, right: String) -> (String, String) {
@@ -316,7 +291,7 @@ private extension UpdateService {
         if globalConfig.isCheckForUpdatesBackgroundEnabled {
             let config = configService.getCurrentConfig()
             let version = app.getVersion()
-            if checkOtaUpdate(config.config, version: version, buildNumber: config.buildNumber) {
+            if checkOtaUpdate(config.config, buildNumber: config.buildNumber) {
                 otaUpdate()
             }
             logInfo("App returned from background, checking for updates...")

--- a/AppliverySDK/Services/UpdateService.swift
+++ b/AppliverySDK/Services/UpdateService.swift
@@ -289,7 +289,6 @@ private extension UpdateService {
     @objc func handleAppWillEnterForeground() {
         if globalConfig.isCheckForUpdatesBackgroundEnabled {
             let config = configService.getCurrentConfig()
-            let version = app.getVersion()
             if checkOtaUpdate(config.config, buildNumber: config.buildNumber) {
                 otaUpdate()
             }

--- a/AppliverySDK/Wrappers/App.swift
+++ b/AppliverySDK/Wrappers/App.swift
@@ -37,13 +37,11 @@ extension AppProtocol {
 	}
 }
 
-
 class App: AppProtocol {
     private lazy var alertOta: UIAlertController = UIAlertController()
     private lazy var alertPostpone: UIAlertController = UIAlertController()
     private lazy var alertError: UIAlertController = UIAlertController()
     private lazy var alertLogin: UIAlertController = UIAlertController()
-
 
     // MARK: - Public Methods
     func deviceAvailableSpace() throws -> Int64 {
@@ -99,8 +97,6 @@ class App: AppProtocol {
 
         return true
     }
-
-
 
     func showAlert(_ message: String) {
         let alert = UIAlertController(title: literal(.appName), message: message, preferredStyle: .alert)

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Starts the Applivery SDK. Call this early in your app's lifecycle.
 - `skipUpdateCheck`: If true, skips the initial update check
 
 ### isUpToDate() -> Bool
-Returns whether the app is up to date with the latest version available.
+Returns whether the app is up to date with the latest version available. **This only takes into account the build number.**
 
 ### update(onDownload: ((UpdateResult) -> Void)?)
 Downloads and installs the newest build available. Call after `start()`.
@@ -283,7 +283,7 @@ Presents the Applivery feedback UI (form for bug reports, suggestions, etc). You
 Handles a redirect URL as part of the SAML authentication flow. See [Handling SAML Redirect URLs](#handling-saml-redirect-urls).
 
 ### checkForUpdates(forceUpdate: Bool)
-Checks for updates and launches the update flow if available. `forceUpdate` ignores postponed time if true.
+Checks for updates and launches the update flow if available. `forceUpdate` ignores postponed time if true. **This only takes into account the build number.**
 
 ### disableScreenshotFeedback()
 Disables listening for screenshot events to trigger feedback.


### PR DESCRIPTION
This pull request updates the Applivery SDK version and improves the logic for checking app updates, particularly around build numbers and versioning. It also clarifies logging messages and corrects test data to better reflect real-world scenarios.

**Versioning and Metadata Updates:**
- Updated the SDK version to `4.5.2` in both the `Applivery.podspec` and `AppliverySDK.swift` files to ensure consistency across the project. [[1]](diffhunk://#diff-d91b8c9d56367343821559d239b096f070296f86f6038e5200abc6314df8b460L3-R3) [[2]](diffhunk://#diff-f86d3e567fed0c23b2547250bbe6181e247a7794549efc32abd602e79511da51L121-R121)

**Update Logic Improvements:**
- Changed the logic in `UpdateService` so that OTA updates are now checked using the app's build number instead of the app version, aligning with typical OTA update practices.
- Updated log messages in `UpdateService` to clarify whether checks are comparing app version or build number, making debugging and maintenance easier. [[1]](diffhunk://#diff-142054b531cf72e61e7607ec5f78e21e2bbd59e6f2c79ce37717c0364b56cc38L150-R150) [[2]](diffhunk://#diff-142054b531cf72e61e7607ec5f78e21e2bbd59e6f2c79ce37717c0364b56cc38L169-R169)

**Test Adjustments:**
- Adjusted test data in `UpdateServiceTests.swift` to use a realistic build number (`101`) for `lastBuildVersion`, and removed a redundant version stub, ensuring tests accurately reflect the new update logic.